### PR TITLE
Make audio type optional and infer type from file extension

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -12,7 +12,6 @@
       "content": "slides/01-intro.md",
       "format": "md",
       "audio": {
-        "type": "txt",
         "src": "audio/01-intro.txt",
         "lang": "de-DE"
       }
@@ -38,13 +37,15 @@
 
 ### Audio
 
-- `type`: `txt`, `ssml` oder `mp3`
+- `type`: optional; `txt`, `ssml` oder `mp3` (überschreibt die automatische Erkennung)
 - `src`: Pfad zur Audio- bzw. Textquelle
 - `lang`: optional, relevant für TTS
 - `voice`: optionaler Browser-Voice-Name
 - `rate`: optional
 - `pitch`: optional
 - `volume`: optional
+
+Wenn `type` fehlt, wird der Typ automatisch über die Dateiendung von `src` erkannt (`.txt`, `.ssml`, `.mp3`).
 
 ## Pfadauflösung
 

--- a/example/slides.json
+++ b/example/slides.json
@@ -7,7 +7,6 @@
       "content": "slides/01-intro.md",
       "format": "md",
       "audio": {
-        "type": "txt",
         "src": "audio/01-intro.txt",
         "lang": "de-DE",
         "rate": 1.0,

--- a/src/audio.js
+++ b/src/audio.js
@@ -18,7 +18,7 @@ export class AudioController {
       return;
     }
 
-    const audioType = (slide.audio.type || '').toLowerCase();
+    const audioType = inferAudioType(slide.audio);
     this.currentSlideKey = `${slide.id || ''}:${slide.audio.src || audioType}`;
 
     try {
@@ -34,7 +34,7 @@ export class AudioController {
         return;
       }
 
-      this.updateStatus(`Nicht unterstützter Audiotyp: ${audioType}`);
+      this.updateStatus(`Nicht unterstützter Audiotyp: ${audioType || 'unbekannt'}`);
       await this.playFallbackMessage(slide.audio);
     } catch (error) {
       console.warn('Audio konnte nicht geladen werden. Fallback wird gesprochen.', error);
@@ -144,6 +144,31 @@ export class AudioController {
     this.currentMode = status;
     this.onStatusChange?.(status);
   }
+}
+
+function inferAudioType(audioConfig = {}) {
+  const explicitType = String(audioConfig.type || '').trim().toLowerCase();
+  if (explicitType) {
+    return explicitType;
+  }
+
+  const src = String(audioConfig.src || '').trim();
+  if (!src) {
+    return '';
+  }
+
+  const extension = src
+    .split('#', 1)[0]
+    .split('?', 1)[0]
+    .split('.')
+    .pop()
+    ?.toLowerCase();
+
+  if (extension === 'mp3' || extension === 'txt' || extension === 'ssml') {
+    return extension;
+  }
+
+  return '';
 }
 
 function ssmlToSpeechText(ssml) {


### PR DESCRIPTION
### Motivation
- The manifest previously required an explicit `audio.type` which should be optional so the implementation can auto-detect common audio kinds from the file name when `type` is omitted. 
- Explicit `audio.type` must continue to act as an override when present while fallback logic should handle missing or unknown types gracefully.

### Description
- Added `inferAudioType` in `src/audio.js` which returns an explicit `type` if present or infers the type from `audio.src` file extension while ignoring query strings and fragments. 
- Updated `AudioController.play` to use `inferAudioType` and to display `unbekannt` when no supported type can be determined. 
- Updated `docs/manifest.md` to document that `audio.type` is optional and that `.txt`, `.ssml`, and `.mp3` are detected from `src` when `type` is omitted. 
- Adjusted `example/slides.json` to demonstrate automatic detection by removing `type` from one example slide while keeping an explicit `type` on another.

### Testing
- Executed `node --check src/audio.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced3f7a2f4832a8d485a7999d7eaf2)