### PR TITLE
Unterstützung für audio-Kurzschreibweise in slides.json

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -33,19 +33,26 @@
 - `title`: optionaler Anzeigename
 - `content`: Pfad zur Folienquelle
 - `format`: optional `md` oder `wm`
-- `audio`: optionales Audioobjekt
+- `audio`: optional als Audioobjekt **oder** als Kurzschreibweise (String mit Dateipfad)
 
 ### Audio
 
-- `type`: optional; `txt`, `ssml` oder `mp3` (überschreibt die automatische Erkennung)
-- `src`: Pfad zur Audio- bzw. Textquelle
-- `lang`: optional, relevant für TTS
-- `voice`: optionaler Browser-Voice-Name
-- `rate`: optional
-- `pitch`: optional
-- `volume`: optional
+`audio` kann in zwei Formen angegeben werden:
 
-Wenn `type` fehlt, wird der Typ automatisch über die Dateiendung von `src` erkannt (`.txt`, `.ssml`, `.mp3`).
+1. **Objektform**
+   - `type`: optional; `txt`, `ssml` oder `mp3` (überschreibt die automatische Erkennung)
+   - `src`: Pfad zur Audio- bzw. Textquelle
+   - `lang`: optional, relevant für TTS
+   - `voice`: optionaler Browser-Voice-Name
+   - `rate`: optional
+   - `pitch`: optional
+   - `volume`: optional
+
+2. **Kurzform**
+   - `audio`: String mit Dateipfad, z. B. `"audio/01-intro.txt"`
+
+Wenn `type` fehlt, wird der Typ automatisch über die Dateiendung der Quelle erkannt (`.txt`, `.ssml`, `.mp3`) – sowohl in Objektform als auch in Kurzform.
+
 
 ## Pfadauflösung
 

--- a/example/slides.json
+++ b/example/slides.json
@@ -6,12 +6,7 @@
       "title": "Willkommen",
       "content": "slides/01-intro.md",
       "format": "md",
-      "audio": {
-        "src": "audio/01-intro.txt",
-        "lang": "de-DE",
-        "rate": 1.0,
-        "pitch": 1.0
-      }
+      "audio": "audio/01-intro.txt"
     },
     {
       "id": "silent-slide",

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -100,6 +100,7 @@ async function buildDeck(manifest, assetLoader) {
     const contentText = await assetLoader.loadText(contentPath);
     slides.push({
       ...slide,
+      audio: normalizeAudio(slide.audio),
       index,
       showtime: normalizeShowtime(slide.showtime),
       contentPath,
@@ -136,6 +137,20 @@ function validateManifest(manifest) {
       }
     }
   }
+}
+
+
+function normalizeAudio(value) {
+  if (typeof value === 'string') {
+    const src = value.trim();
+    return src ? { src } : undefined;
+  }
+
+  if (value && typeof value === 'object') {
+    return value;
+  }
+
+  return undefined;
 }
 
 function normalizeShowtime(value) {


### PR DESCRIPTION
### Motivation

- Manifest-Autoren sollen `audio` vereinfacht als Kurzform angeben können (z. B. `"audio": "audio/01-intro.txt"`) ohne bestehende Laufzeitlogik zu ändern.
- Die automatische Ermittlung des Audiotyps über die Dateiendung soll unverändert weiter funktionieren.

### Description

- Füge in `src/loaders.js` die Hilfsfunktion `normalizeAudio` hinzu, die eine String-Kurzform in ein internes Audioobjekt (`{ src: ... }`) umwandelt und bestehende Objekte unangetastet lässt.
- In `buildDeck` werden Slide-Einträge jetzt mit `audio: normalizeAudio(slide.audio)` normalisiert, bevor sie in das Deck übernommen werden.
- Dokumentation `docs/manifest.md` wurde ergänzt, um die zwei möglichen Formen von `audio` (Objektform und Kurzform) zu beschreiben und zu erklären, dass die Dateiendungs-basierte Typ-Erkennung in beiden Fällen gilt.
- Beispiel `example/slides.json` wurde angepasst, damit die erste Folie die neue Kurzschreibweise zeigt.

### Testing

- Syntaxprüfung mit `node --check src/loaders.js` wurde ausgeführt und lieferte keinen Fehler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cedb79206c832a8366c50cb0cca51c)