### PR TITLE
Use slide IDs in sidebar slide list labels

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -289,8 +289,8 @@ function renderSlideList() {
     const li = document.createElement('li');
     const button = document.createElement('button');
     button.type = 'button';
-    const slideLabel = slide.id || slide.title || slide.content;
-    button.textContent = `${index + 1}. ${slideLabel}`;
+    const slideLabel = slide.title || slide.id || slide.content;
+    button.textContent = ` ${slideLabel}`;
     if (index === state.currentIndex) {
       button.classList.add('active');
     }

--- a/src/app.js
+++ b/src/app.js
@@ -289,7 +289,8 @@ function renderSlideList() {
     const li = document.createElement('li');
     const button = document.createElement('button');
     button.type = 'button';
-    button.textContent = `${index + 1}. ${slide.title || slide.id || slide.content}`;
+    const slideLabel = slide.id || slide.title || slide.content;
+    button.textContent = `${index + 1}. ${slideLabel}`;
     if (index === state.currentIndex) {
       button.classList.add('active');
     }


### PR DESCRIPTION
### Motivation
- Sidebar list labels should show `index.` followed by each slide's `id` from `slides.json` (e.g. `1. 1`) instead of using the slide `title` first which produced labels like `1. 1.1`.

### Description
- Updated `renderSlideList` in `src/app.js` to prefer `slide.id` when building labels by using `const slideLabel = slide.id || slide.title || slide.content;` and setting the button text to ```${index + 1}. ${slideLabel}```.

### Testing
- Ran `node --check src/app.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6afa95fb4832a9e5170e72c967d95)