### PR TITLE
Add transcript panel to show slide audio text or playable audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,21 @@
             </button>
           </div>
           <div class="toolbar-group">
-            <button id="transcript-toggle-btn" type="button" title="Audioinhalt anzeigen" aria-expanded="false">Text/Audio anzeigen</button>
+            <button
+              id="transcript-toggle-btn"
+              class="icon-btn icon-btn--transcript"
+              type="button"
+              title="Audiotext einblenden"
+              aria-label="Audiotext einblenden"
+              aria-expanded="false"
+              aria-pressed="false"
+            >
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M2 12s3.8-6 10-6 10 6 10 6-3.8 6-10 6-10-6-10-6z" />
+                <circle cx="12" cy="12" r="2.8" />
+                <path class="transcript-eye-slash" d="M4 4l16 16" />
+              </svg>
+            </button>
             <label for="goto-input">Gehe zu</label>
             <input id="goto-input" type="number" min="1" step="1" value="1">
             <button id="goto-btn" type="button">Los</button>

--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
             </button>
           </div>
           <div class="toolbar-group">
+            <button id="transcript-toggle-btn" type="button" title="Audioinhalt anzeigen" aria-expanded="false">Text/Audio anzeigen</button>
             <label for="goto-input">Gehe zu</label>
             <input id="goto-input" type="number" min="1" step="1" value="1">
             <button id="goto-btn" type="button">Los</button>
@@ -117,6 +118,13 @@
             </label>
           </div>
         </header>
+
+        <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
+          <h3>Audioinhalt der aktuellen Folie</h3>
+          <p id="transcript-hint" class="muted small"></p>
+          <audio id="transcript-audio-player" controls class="hidden"></audio>
+          <pre id="transcript-text" class="hidden"></pre>
+        </section>
 
         <article id="slide-stage" class="slide-stage">
           <div class="placeholder">

--- a/src/app.js
+++ b/src/app.js
@@ -402,7 +402,7 @@ async function renderTranscriptContent({ keepOpen = false } = {}) {
       const textContent = await state.deck.assetLoader.loadText(slide.audio.src);
       elements.transcriptText.textContent = audioType === 'ssml'
         ? ssmlToDisplayText(textContent)
-        : textContent.trim();
+        : preserveStructuredText(textContent);
       elements.transcriptText.classList.remove('hidden');
       elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
     } catch (error) {
@@ -476,11 +476,18 @@ function inferAudioType(audioConfig = {}) {
 }
 
 function ssmlToDisplayText(ssml) {
-  return ssml
-    .replace(/<break[^>]*time="(.*?)"[^>]*\/>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  const normalized = String(ssml).replace(/\r\n?/g, '\n');
+  const withStructure = normalized
+    .replace(/<\s*break\b[^>]*\/?>/gi, '\n')
+    .replace(/<\s*br\s*\/?>/gi, '\n')
+    .replace(/<\s*\/\s*(p|div|section|article|li|ul|ol|h1|h2|h3|h4|h5|h6)\s*>/gi, '\n')
+    .replace(/<\s*\/\s*(s|sentence)\s*>/gi, '\n')
+    .replace(/<\s*\/\s*(speak|paragraph)\s*>/gi, '\n\n');
+
+  const withoutTags = withStructure.replace(/<[^>]+>/g, '');
+  const decoded = decodeSimpleXmlEntities(withoutTags);
+
+  return preserveStructuredText(decoded);
 }
 
 function isTextAudioType(audioType) {
@@ -500,4 +507,22 @@ function isPlayableAudioType(audioType, sourcePath = '') {
     ?.toLowerCase();
 
   return ['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac', 'webm'].includes(extension || '');
+}
+
+function preserveStructuredText(text) {
+  return String(text)
+    .replace(/\r\n?/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function decodeSimpleXmlEntities(text) {
+  return String(text)
+    .replaceAll('&nbsp;', ' ')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
 }

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,11 @@ const elements = {
   slideList: document.querySelector('#slide-list'),
   slideStage: document.querySelector('#slide-stage'),
   gotoInput: document.querySelector('#goto-input'),
+  transcriptToggleBtn: document.querySelector('#transcript-toggle-btn'),
+  transcriptPanel: document.querySelector('#transcript-panel'),
+  transcriptHint: document.querySelector('#transcript-hint'),
+  transcriptText: document.querySelector('#transcript-text'),
+  transcriptAudioPlayer: document.querySelector('#transcript-audio-player'),
   autoplayNextCheckbox: document.querySelector('#autoplay-next-checkbox'),
   remoteUrlInput: document.querySelector('#remote-url-input'),
   zipInput: document.querySelector('#zip-input'),
@@ -113,6 +118,9 @@ function bindEvents() {
   elements.autoplayNextCheckbox.addEventListener('change', () => {
     state.autoAdvance = elements.autoplayNextCheckbox.checked;
   });
+  elements.transcriptToggleBtn.addEventListener('click', async () => {
+    await toggleTranscriptPanel();
+  });
 
   document.addEventListener('keydown', async (event) => {
     if (event.target instanceof HTMLInputElement) {
@@ -201,6 +209,7 @@ async function setDeck(deck) {
   state.sourceKind = deck.sourceKind;
   state.currentIndex = 0;
   await audioController.stop();
+  hideTranscriptPanel();
   refreshUi();
   renderSlideList();
   await renderCurrentSlide();
@@ -229,6 +238,7 @@ async function renderCurrentSlide() {
   const slide = state.deck?.slides[state.currentIndex];
   if (!slide) {
     elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
+    hideTranscriptPanel();
     return;
   }
 
@@ -251,6 +261,14 @@ async function renderCurrentSlide() {
 
   if (!slide.audio) {
     updateSlideAudioStatus(slide);
+    if (isTranscriptPanelOpen()) {
+      await renderTranscriptContent({ keepOpen: true });
+    }
+    return;
+  }
+
+  if (isTranscriptPanelOpen()) {
+    await renderTranscriptContent({ keepOpen: true });
   }
 }
 
@@ -326,6 +344,84 @@ function refreshUi() {
   ]) {
     button.disabled = disabled;
   }
+
+  elements.transcriptToggleBtn.disabled = disabled;
+}
+
+async function toggleTranscriptPanel() {
+  const shouldOpen = !isTranscriptPanelOpen();
+  if (shouldOpen) {
+    await renderTranscriptContent({ keepOpen: true });
+    return;
+  }
+  setTranscriptPanelVisibility(shouldOpen);
+}
+
+function setTranscriptPanelVisibility(isVisible) {
+  elements.transcriptPanel.classList.toggle('hidden', !isVisible);
+  elements.transcriptToggleBtn.setAttribute('aria-expanded', String(isVisible));
+  elements.transcriptToggleBtn.textContent = isVisible ? 'Text/Audio ausblenden' : 'Text/Audio anzeigen';
+}
+
+function hideTranscriptPanel() {
+  setTranscriptPanelVisibility(false);
+  clearTranscriptPanelContent();
+}
+
+function clearTranscriptPanelContent() {
+  elements.transcriptHint.textContent = '';
+  elements.transcriptText.textContent = '';
+  elements.transcriptText.classList.add('hidden');
+  elements.transcriptAudioPlayer.pause();
+  elements.transcriptAudioPlayer.removeAttribute('src');
+  elements.transcriptAudioPlayer.classList.add('hidden');
+}
+
+function isTranscriptPanelOpen() {
+  return !elements.transcriptPanel.classList.contains('hidden');
+}
+
+async function renderTranscriptContent({ keepOpen = false } = {}) {
+  const slide = state.deck?.slides[state.currentIndex];
+  clearTranscriptPanelContent();
+
+  if (!slide?.audio?.src) {
+    elements.transcriptHint.textContent = 'Für diese Folie ist keine Audioquelle hinterlegt.';
+    setTranscriptPanelVisibility(keepOpen);
+    return;
+  }
+
+  const audioType = inferAudioType(slide.audio);
+
+  if (isTextAudioType(audioType)) {
+    try {
+      const textContent = await state.deck.assetLoader.loadText(slide.audio.src);
+      elements.transcriptText.textContent = audioType === 'ssml'
+        ? ssmlToDisplayText(textContent)
+        : textContent.trim();
+      elements.transcriptText.classList.remove('hidden');
+      elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
+    } catch (error) {
+      elements.transcriptHint.textContent = 'Der Text zur Audio-Datei konnte nicht geladen werden.';
+    }
+    setTranscriptPanelVisibility(keepOpen);
+    return;
+  }
+
+  if (isPlayableAudioType(audioType, slide.audio.src)) {
+    try {
+      elements.transcriptAudioPlayer.src = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+      elements.transcriptAudioPlayer.classList.remove('hidden');
+      elements.transcriptHint.textContent = 'Für diese Folie liegt eine Audio-Datei vor. Du kannst im Player navigieren.';
+    } catch (error) {
+      elements.transcriptHint.textContent = 'Die Audio-Datei für den Player konnte nicht geladen werden.';
+    }
+    setTranscriptPanelVisibility(keepOpen);
+    return;
+  }
+
+  elements.transcriptHint.textContent = 'Der Audio-Typ dieser Folie wird für die Text/Audio-Anzeige nicht unterstützt.';
+  setTranscriptPanelVisibility(keepOpen);
 }
 
 async function withErrorHandling(fn) {
@@ -354,4 +450,50 @@ function escapeHtml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
+}
+
+function inferAudioType(audioConfig = {}) {
+  const explicitType = String(audioConfig.type || '').trim().toLowerCase();
+  if (explicitType) {
+    return explicitType;
+  }
+
+  const src = String(audioConfig.src || '').trim();
+  if (!src) {
+    return '';
+  }
+
+  return src
+    .split('#', 1)[0]
+    .split('?', 1)[0]
+    .split('.')
+    .pop()
+    ?.toLowerCase();
+}
+
+function ssmlToDisplayText(ssml) {
+  return ssml
+    .replace(/<break[^>]*time="(.*?)"[^>]*\/>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isTextAudioType(audioType) {
+  return audioType === 'txt' || audioType === 'ssml';
+}
+
+function isPlayableAudioType(audioType, sourcePath = '') {
+  if (audioType && !isTextAudioType(audioType)) {
+    return true;
+  }
+
+  const extension = String(sourcePath)
+    .split('#', 1)[0]
+    .split('?', 1)[0]
+    .split('.')
+    .pop()
+    ?.toLowerCase();
+
+  return ['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac', 'webm'].includes(extension || '');
 }

--- a/src/app.js
+++ b/src/app.js
@@ -521,7 +521,7 @@ function isPlayableAudioType(audioType, sourcePath = '') {
     .pop()
     ?.toLowerCase();
 
-  return ['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac', 'webm'].includes(extension || '');
+  return ['mp3', 'm4a', 'aac', 'wav', 'ogg', 'oga', 'opus', 'flac', 'webm', 'mp4'].includes(extension || '');
 }
 
 function preserveStructuredText(text) {
@@ -557,10 +557,13 @@ function inferMimeType(audioType, sourcePath) {
   if (normalizedType === 'mp3') return 'audio/mpeg';
   if (normalizedType === 'wav') return 'audio/wav';
   if (normalizedType === 'ogg') return 'audio/ogg';
+  if (normalizedType === 'oga') return 'audio/ogg';
+  if (normalizedType === 'opus') return 'audio/ogg; codecs=opus';
   if (normalizedType === 'm4a') return 'audio/mp4';
   if (normalizedType === 'aac') return 'audio/aac';
   if (normalizedType === 'flac') return 'audio/flac';
   if (normalizedType === 'webm') return 'audio/webm';
+  if (normalizedType === 'mp4') return 'audio/mp4';
 
   const extension = String(sourcePath)
     .split('#', 1)[0]
@@ -575,10 +578,13 @@ function inferMimeType(audioType, sourcePath) {
     mp3: 'audio/mpeg',
     wav: 'audio/wav',
     ogg: 'audio/ogg',
+    oga: 'audio/ogg',
+    opus: 'audio/ogg; codecs=opus',
     m4a: 'audio/mp4',
     aac: 'audio/aac',
     flac: 'audio/flac',
     webm: 'audio/webm',
+    mp4: 'audio/mp4',
   };
 
   return extensionToMime[extension] || '';

--- a/src/app.js
+++ b/src/app.js
@@ -360,7 +360,11 @@ async function toggleTranscriptPanel() {
 function setTranscriptPanelVisibility(isVisible) {
   elements.transcriptPanel.classList.toggle('hidden', !isVisible);
   elements.transcriptToggleBtn.setAttribute('aria-expanded', String(isVisible));
-  elements.transcriptToggleBtn.textContent = isVisible ? 'Text/Audio ausblenden' : 'Text/Audio anzeigen';
+  elements.transcriptToggleBtn.setAttribute('aria-pressed', String(isVisible));
+  elements.transcriptToggleBtn.classList.toggle('is-open', isVisible);
+  const tooltipText = isVisible ? 'Audiotext ausblenden' : 'Audiotext einblenden';
+  elements.transcriptToggleBtn.title = tooltipText;
+  elements.transcriptToggleBtn.setAttribute('aria-label', tooltipText);
 }
 
 function hideTranscriptPanel() {

--- a/src/app.js
+++ b/src/app.js
@@ -378,6 +378,7 @@ function clearTranscriptPanelContent() {
   elements.transcriptText.classList.add('hidden');
   elements.transcriptAudioPlayer.pause();
   elements.transcriptAudioPlayer.removeAttribute('src');
+  elements.transcriptAudioPlayer.classList.remove('is-disabled');
   elements.transcriptAudioPlayer.classList.add('hidden');
 }
 
@@ -396,6 +397,20 @@ async function renderTranscriptContent({ keepOpen = false } = {}) {
   }
 
   const audioType = inferAudioType(slide.audio);
+  elements.transcriptAudioPlayer.classList.remove('hidden');
+
+  try {
+    const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+    elements.transcriptAudioPlayer.src = resolvedSource;
+    const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
+    elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
+    if (!playableInBrowser) {
+      elements.transcriptAudioPlayer.pause();
+    }
+  } catch (error) {
+    elements.transcriptAudioPlayer.classList.add('is-disabled');
+    elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
+  }
 
   if (isTextAudioType(audioType)) {
     try {
@@ -404,7 +419,9 @@ async function renderTranscriptContent({ keepOpen = false } = {}) {
         ? ssmlToDisplayText(textContent)
         : preserveStructuredText(textContent);
       elements.transcriptText.classList.remove('hidden');
-      elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
+      if (!elements.transcriptHint.textContent) {
+        elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
+      }
     } catch (error) {
       elements.transcriptHint.textContent = 'Der Text zur Audio-Datei konnte nicht geladen werden.';
     }
@@ -413,18 +430,16 @@ async function renderTranscriptContent({ keepOpen = false } = {}) {
   }
 
   if (isPlayableAudioType(audioType, slide.audio.src)) {
-    try {
-      elements.transcriptAudioPlayer.src = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
-      elements.transcriptAudioPlayer.classList.remove('hidden');
+    if (!elements.transcriptHint.textContent) {
       elements.transcriptHint.textContent = 'Für diese Folie liegt eine Audio-Datei vor. Du kannst im Player navigieren.';
-    } catch (error) {
-      elements.transcriptHint.textContent = 'Die Audio-Datei für den Player konnte nicht geladen werden.';
     }
     setTranscriptPanelVisibility(keepOpen);
     return;
   }
 
-  elements.transcriptHint.textContent = 'Der Audio-Typ dieser Folie wird für die Text/Audio-Anzeige nicht unterstützt.';
+  if (!elements.transcriptHint.textContent) {
+    elements.transcriptHint.textContent = 'Der Audio-Typ dieser Folie wird für die Text/Audio-Anzeige nicht unterstützt.';
+  }
   setTranscriptPanelVisibility(keepOpen);
 }
 
@@ -525,4 +540,46 @@ function decodeSimpleXmlEntities(text) {
     .replaceAll('&gt;', '>')
     .replaceAll('&quot;', '"')
     .replaceAll('&apos;', "'");
+}
+
+function canPlayInAudioElement(audioElement, audioType, sourcePath) {
+  const mimeType = inferMimeType(audioType, sourcePath);
+  if (!mimeType) {
+    return false;
+  }
+  return audioElement.canPlayType(mimeType) !== '';
+}
+
+function inferMimeType(audioType, sourcePath) {
+  const normalizedType = String(audioType || '').toLowerCase();
+  if (normalizedType === 'ssml') return 'application/ssml+xml';
+  if (normalizedType === 'txt') return 'text/plain';
+  if (normalizedType === 'mp3') return 'audio/mpeg';
+  if (normalizedType === 'wav') return 'audio/wav';
+  if (normalizedType === 'ogg') return 'audio/ogg';
+  if (normalizedType === 'm4a') return 'audio/mp4';
+  if (normalizedType === 'aac') return 'audio/aac';
+  if (normalizedType === 'flac') return 'audio/flac';
+  if (normalizedType === 'webm') return 'audio/webm';
+
+  const extension = String(sourcePath)
+    .split('#', 1)[0]
+    .split('?', 1)[0]
+    .split('.')
+    .pop()
+    ?.toLowerCase();
+
+  const extensionToMime = {
+    ssml: 'application/ssml+xml',
+    txt: 'text/plain',
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+    ogg: 'audio/ogg',
+    m4a: 'audio/mp4',
+    aac: 'audio/aac',
+    flac: 'audio/flac',
+    webm: 'audio/webm',
+  };
+
+  return extensionToMime[extension] || '';
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -22,7 +22,7 @@ export class AudioController {
     this.currentSlideKey = `${slide.id || ''}:${slide.audio.src || audioType}`;
 
     try {
-      if (audioType === 'mp3') {
+      if (isPlayableAudioType(audioType)) {
         const resolvedUrl = await assetLoader.resolvePlayableUrl(slide.audio.src);
         await this.playAudioElement(resolvedUrl);
         return;
@@ -90,7 +90,7 @@ export class AudioController {
       this.onEnded?.();
     }, { once: true });
     audio.addEventListener('error', async () => {
-      console.warn('MP3 konnte nicht abgespielt werden. Fallback wird gesprochen.', url);
+      console.warn('Audio-Datei konnte nicht abgespielt werden. Fallback wird gesprochen.', url);
       this.audio = null;
       this.updateStatus('Audio-Datei fehlt oder ist nicht erreichbar');
       await this.playFallbackMessage();
@@ -164,11 +164,7 @@ function inferAudioType(audioConfig = {}) {
     .pop()
     ?.toLowerCase();
 
-  if (extension === 'mp3' || extension === 'txt' || extension === 'ssml') {
-    return extension;
-  }
-
-  return '';
+  return extension || '';
 }
 
 function ssmlToSpeechText(ssml) {
@@ -177,4 +173,19 @@ function ssmlToSpeechText(ssml) {
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function isPlayableAudioType(audioType) {
+  return [
+    'mp3',
+    'm4a',
+    'aac',
+    'wav',
+    'ogg',
+    'oga',
+    'opus',
+    'flac',
+    'webm',
+    'mp4',
+  ].includes(String(audioType || '').toLowerCase());
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,6 +54,35 @@ code { font-family: Consolas, Monaco, monospace; }
   gap: 8px;
 }
 
+.transcript-panel {
+  margin: 12px 18px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(35, 42, 52, 0.55);
+}
+
+.transcript-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.transcript-panel pre {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  white-space: pre-wrap;
+  background: rgba(19, 22, 26, 0.75);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+#transcript-audio-player {
+  display: block;
+  margin-top: 10px;
+  width: min(540px, 100%);
+}
+
 button,
 .file-label,
 input[type="url"],

--- a/src/styles.css
+++ b/src/styles.css
@@ -135,6 +135,14 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
   stroke: none;
 }
 
+.icon-btn--transcript .transcript-eye-slash {
+  display: none;
+}
+
+.icon-btn--transcript.is-open .transcript-eye-slash {
+  display: block;
+}
+
 .toolbar-group--primary {
   gap: 10px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,6 +145,7 @@ button:disabled { opacity: 0.55; cursor: not-allowed; }
 
 .toolbar-group--primary {
   gap: 10px;
+  flex-wrap: nowrap;
 }
 
 input[type="url"],

--- a/src/styles.css
+++ b/src/styles.css
@@ -83,6 +83,12 @@ code { font-family: Consolas, Monaco, monospace; }
   width: min(540px, 100%);
 }
 
+#transcript-audio-player.is-disabled {
+  opacity: 0.45;
+  filter: grayscale(1);
+  pointer-events: none;
+}
+
 button,
 .file-label,
 input[type="url"],


### PR DESCRIPTION
### Motivation
- Provide an accessible way to view the audio content of the current slide either as displayable text (plain text or SSML) or as a playable audio file. 
- Allow users to toggle a dedicated transcript panel from the toolbar and keep it synchronized with slide navigation and deck loading.

### Description
- Added a toggle button in the toolbar and a new `#transcript-panel` section in `index.html` that contains a hint, an audio player, and a `pre` for rendered text.
- Implemented transcript UI logic in `src/app.js` including `toggleTranscriptPanel`, panel visibility helpers, `renderTranscriptContent`, `clearTranscriptPanelContent`, and `hideTranscriptPanel`, and wired the button to the handler.
- Added audio-type inference and helpers `inferAudioType`, `isTextAudioType`, `isPlayableAudioType`, and `ssmlToDisplayText` to handle text (e.g. `txt`, `ssml`) and common audio formats and to convert SSML to displayable text.
- Ensured panel state is reset when loading decks or when no slide is selected, and disabled the transcript toggle when no deck is loaded.
- Added styles for the transcript panel and audio player in `src/styles.css`.

### Testing
- Ran the existing automated test suite with `npm test` after the changes and the suite completed successfully. 
- No new automated tests were added for the transcript feature in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6bb9bd998832a81203a2656f5cd01)