### PR TITLE
Add subtle bell cue before slide transitions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,10 @@ let slideChangeCueAudioContext = null;
 const SLIDE_CHANGE_BELL_VOLUME = 5.0;
 const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.045;
 const SLIDE_CHANGE_BELL_DECAY_SECONDS = 1.8;
-const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 2;
+const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.5;
+const TRANSITION_UNLOCK_TIMEOUT_MS = 10_000;
+let isSlideTransitionInProgress = false;
+let transitionUnlockTimer = null;
 
 const elements = {
   deckTitle: document.querySelector('#deck-title'),
@@ -128,6 +131,9 @@ function bindEvents() {
   });
 
   document.addEventListener('keydown', async (event) => {
+    if (isSlideTransitionInProgress) {
+      return;
+    }
     if (event.target instanceof HTMLInputElement) {
       return;
     }
@@ -147,6 +153,41 @@ function clearSlideAdvanceTimer() {
     window.clearTimeout(slideAdvanceTimer);
     slideAdvanceTimer = null;
   }
+}
+
+function beginSlideTransitionLock() {
+  isSlideTransitionInProgress = true;
+  refreshUi();
+  setSlideListNavigationDisabled(true);
+  clearTransitionUnlockTimer();
+  transitionUnlockTimer = window.setTimeout(() => {
+    if (!isSlideTransitionInProgress) {
+      return;
+    }
+    console.warn('Navigation wurde per Notfall-Timeout entsperrt.');
+    endSlideTransitionLock();
+  }, TRANSITION_UNLOCK_TIMEOUT_MS);
+}
+
+function endSlideTransitionLock() {
+  isSlideTransitionInProgress = false;
+  clearTransitionUnlockTimer();
+  refreshUi();
+  setSlideListNavigationDisabled(false);
+}
+
+function clearTransitionUnlockTimer() {
+  if (transitionUnlockTimer) {
+    window.clearTimeout(transitionUnlockTimer);
+    transitionUnlockTimer = null;
+  }
+}
+
+function setSlideListNavigationDisabled(disabled) {
+  const buttons = elements.slideList.querySelectorAll('button');
+  buttons.forEach((button) => {
+    button.disabled = disabled;
+  });
 }
 
 function getSlideShowtimeSeconds(slide) {
@@ -221,23 +262,31 @@ async function setDeck(deck) {
 }
 
 async function goToSlide(index, options = {}) {
+  if (isSlideTransitionInProgress) {
+    return;
+  }
   if (!state.deck) {
     return;
   }
   if (index < 0 || index >= state.deck.slides.length) {
     return;
   }
-  const bellDurationSeconds = playSlideChangeCue();
-  await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
-  clearSlideAdvanceTimer();
-  state.currentIndex = index;
-  await audioController.stop();
-  hideTranscriptPanel();
-  refreshUi();
-  renderSlideList();
-  await renderCurrentSlide();
-  if (options.autoplay) {
-    await playCurrentSlide();
+  beginSlideTransitionLock();
+  try {
+    const bellDurationSeconds = playSlideChangeCue();
+    await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
+    clearSlideAdvanceTimer();
+    state.currentIndex = index;
+    await audioController.stop();
+    hideTranscriptPanel();
+    refreshUi();
+    renderSlideList();
+    await renderCurrentSlide();
+    if (options.autoplay) {
+      await playCurrentSlide();
+    }
+  } finally {
+    endSlideTransitionLock();
   }
 }
 
@@ -354,6 +403,9 @@ async function hydrateAsyncAssets() {
 }
 
 async function playCurrentSlide() {
+  if (isSlideTransitionInProgress) {
+    return;
+  }
   const slide = state.deck?.slides[state.currentIndex];
   if (!slide) {
     return;
@@ -382,6 +434,7 @@ function renderSlideList() {
     if (index === state.currentIndex) {
       button.classList.add('active');
     }
+    button.disabled = isSlideTransitionInProgress;
     button.addEventListener('click', () => {
       void goToSlide(index);
     });
@@ -401,7 +454,7 @@ function refreshUi() {
   elements.gotoInput.value = slideCount > 0 ? String(state.currentIndex + 1) : '1';
   elements.autoplayNextCheckbox.checked = state.autoAdvance;
 
-  const disabled = !state.deck;
+  const disabled = !state.deck || isSlideTransitionInProgress;
   for (const button of [
     elements.firstBtn,
     elements.prevBtn,
@@ -415,6 +468,7 @@ function refreshUi() {
     button.disabled = disabled;
   }
 
+  elements.gotoInput.disabled = disabled;
   elements.transcriptToggleBtn.disabled = disabled;
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,9 @@ import { loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote } from './lo
 const state = createInitialState();
 let slideAdvanceTimer = null;
 let slideChangeCueAudioContext = null;
+const SLIDE_CHANGE_BELL_VOLUME = 0.03;
+const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.045;
+const SLIDE_CHANGE_BELL_DECAY_SECONDS = 1.8;
 
 const elements = {
   deckTitle: document.querySelector('#deck-title'),
@@ -252,22 +255,39 @@ function playSlideChangeCue() {
     }
 
     const now = context.currentTime;
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
+    const attackEnd = now + SLIDE_CHANGE_BELL_STRIKE_SECONDS;
+    const releaseEnd = attackEnd + SLIDE_CHANGE_BELL_DECAY_SECONDS;
+    const masterGain = context.createGain();
+    const bellVoices = [
+      { frequency: 110, level: 1.0, type: 'sine', detune: -3 },
+      { frequency: 165, level: 0.7, type: 'triangle', detune: 2 },
+      { frequency: 220, level: 0.45, type: 'sine', detune: -1 },
+      { frequency: 277, level: 0.3, type: 'sine', detune: 1 },
+      { frequency: 330, level: 0.2, type: 'triangle', detune: 0 },
+    ];
 
-    oscillator.type = 'sine';
-    oscillator.frequency.setValueAtTime(880, now);
-    oscillator.frequency.exponentialRampToValueAtTime(1320, now + 0.08);
+    masterGain.gain.setValueAtTime(0.0001, now);
+    masterGain.gain.exponentialRampToValueAtTime(SLIDE_CHANGE_BELL_VOLUME, attackEnd);
+    masterGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
+    masterGain.connect(context.destination);
 
-    gain.gain.setValueAtTime(0.0001, now);
-    gain.gain.exponentialRampToValueAtTime(0.02, now + 0.015);
-    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.18);
+    bellVoices.forEach(({ frequency, level, type, detune }) => {
+      const oscillator = context.createOscillator();
+      const voiceGain = context.createGain();
+      oscillator.type = type;
+      oscillator.frequency.setValueAtTime(frequency, now);
+      oscillator.detune.setValueAtTime(detune, now);
+      oscillator.detune.linearRampToValueAtTime(detune * 0.4, releaseEnd);
 
-    oscillator.connect(gain);
-    gain.connect(context.destination);
+      voiceGain.gain.setValueAtTime(Math.max(0.0001, level * 0.001), now);
+      voiceGain.gain.exponentialRampToValueAtTime(Math.max(0.0001, level), attackEnd);
+      voiceGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
 
-    oscillator.start(now);
-    oscillator.stop(now + 0.2);
+      oscillator.connect(voiceGain);
+      voiceGain.connect(masterGain);
+      oscillator.start(now);
+      oscillator.stop(releaseEnd + 0.05);
+    });
   } catch (error) {
     console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);
   }

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import { loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote } from './lo
 
 const state = createInitialState();
 let slideAdvanceTimer = null;
+let slideChangeCueAudioContext = null;
 
 const elements = {
   deckTitle: document.querySelector('#deck-title'),
@@ -222,6 +223,7 @@ async function goToSlide(index, options = {}) {
   if (index < 0 || index >= state.deck.slides.length) {
     return;
   }
+  playSlideChangeCue();
   clearSlideAdvanceTimer();
   state.currentIndex = index;
   await audioController.stop();
@@ -231,6 +233,43 @@ async function goToSlide(index, options = {}) {
   await renderCurrentSlide();
   if (options.autoplay) {
     await playCurrentSlide();
+  }
+}
+
+function playSlideChangeCue() {
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextClass) {
+    return;
+  }
+
+  try {
+    if (!slideChangeCueAudioContext) {
+      slideChangeCueAudioContext = new AudioContextClass();
+    }
+    const context = slideChangeCueAudioContext;
+    if (context.state === 'suspended') {
+      context.resume().catch(() => {});
+    }
+
+    const now = context.currentTime;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(880, now);
+    oscillator.frequency.exponentialRampToValueAtTime(1320, now + 0.08);
+
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.02, now + 0.015);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.18);
+
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + 0.2);
+  } catch (error) {
+    console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -283,7 +283,7 @@ async function goToSlide(index, options = {}) {
     renderSlideList();
     await renderCurrentSlide();
     if (options.autoplay) {
-      await playCurrentSlide();
+      await playCurrentSlide({ ignoreTransitionLock: true });
     }
   } finally {
     endSlideTransitionLock();
@@ -402,8 +402,8 @@ async function hydrateAsyncAssets() {
   }
 }
 
-async function playCurrentSlide() {
-  if (isSlideTransitionInProgress) {
+async function playCurrentSlide(options = {}) {
+  if (isSlideTransitionInProgress && !options.ignoreTransitionLock) {
     return;
   }
   const slide = state.deck?.slides[state.currentIndex];

--- a/src/app.js
+++ b/src/app.js
@@ -6,9 +6,10 @@ import { loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote } from './lo
 const state = createInitialState();
 let slideAdvanceTimer = null;
 let slideChangeCueAudioContext = null;
-const SLIDE_CHANGE_BELL_VOLUME = 0.03;
+const SLIDE_CHANGE_BELL_VOLUME = 5.0;
 const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.045;
 const SLIDE_CHANGE_BELL_DECAY_SECONDS = 1.8;
+const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 2;
 
 const elements = {
   deckTitle: document.querySelector('#deck-title'),
@@ -226,7 +227,8 @@ async function goToSlide(index, options = {}) {
   if (index < 0 || index >= state.deck.slides.length) {
     return;
   }
-  playSlideChangeCue();
+  const bellDurationSeconds = playSlideChangeCue();
+  await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
   clearSlideAdvanceTimer();
   state.currentIndex = index;
   await audioController.stop();
@@ -242,7 +244,7 @@ async function goToSlide(index, options = {}) {
 function playSlideChangeCue() {
   const AudioContextClass = window.AudioContext || window.webkitAudioContext;
   if (!AudioContextClass) {
-    return;
+    return 0;
   }
 
   try {
@@ -288,9 +290,17 @@ function playSlideChangeCue() {
       oscillator.start(now);
       oscillator.stop(releaseEnd + 0.05);
     });
+    return SLIDE_CHANGE_BELL_STRIKE_SECONDS + SLIDE_CHANGE_BELL_DECAY_SECONDS;
   } catch (error) {
     console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);
+    return 0;
   }
+}
+
+function delay(durationMs) {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, durationMs);
+  });
 }
 
 async function renderCurrentSlide() {


### PR DESCRIPTION
### Motivation
- Notify listeners of an initiated slide change by playing a short, subtle cue at the very start of a navigation event using `gotoSlide`.
- Ensure the cue runs before any slide audio is stopped or started so it cannot overlap with audio that begins on the target slide.
- Use a low-volume, brief sound that is unlikely to be obtrusive while still providing an accessible signal.

### Description
- Call `playSlideChangeCue()` immediately after index validation at the start of `goToSlide` so the cue plays before `audioController.stop()` and rendering logic.
- Add a module-scoped `slideChangeCueAudioContext` to reuse a single `AudioContext` across cues instead of creating a new one per change.
- Implement `playSlideChangeCue()` using the Web Audio API with a sine oscillator, a short upward pitch sweep, and a soft gain envelope, and resume the context if it is suspended.
- Fail gracefully when the Web Audio APIs are not available or if playback cannot be started, logging a debug message without throwing.

### Testing
- Ran `node --check src/app.js && node --check src/audio.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d804d3ec80832a89a806d31dde14ba)