### PR TITLE
Avoid TTS attempts when SpeechSynthesis exists but is unusable

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -593,7 +593,7 @@ function checkAudioSupport() {
     if (!audioController.isSpeechReallyUsable()) {
         showError(`
         ⚠️ Sprachwiedergabe wird von diesem Browser nicht unterstützt.
-        👉 Bitte öffne die Slideshow im Chrome Browser.
+        👉 Bitte nutze Audio-Dateien (mp3/ogg/...) statt TTS (txt/ssml), oder verwende ein Gerät mit funktionierender SpeechSynthesis.
         `);
     }
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -74,7 +74,7 @@ export class AudioController {
             return;
         }
 
-        if (this.synthesis.speaking && !this.synthesis.paused) {
+        if (this.synthesis?.speaking && !this.synthesis.paused) {
             this.synthesis.pause();
             this.updateStatus('Pausiert');
         }
@@ -87,7 +87,7 @@ export class AudioController {
             return;
         }
 
-        if (this.synthesis.paused) {
+        if (this.synthesis?.paused) {
             this.synthesis.resume();
             this.updateStatus('Spielt');
         }
@@ -148,10 +148,25 @@ export class AudioController {
     }
 
     async playFallbackMessage(audioConfig = {}, playbackSession) {
+        if (!this.isSpeechReallyUsable()) {
+            this.updateStatus('Audio nicht verfügbar');
+            if (this.isCurrentPlaybackSession(playbackSession)) {
+                this.onEnded?.();
+            }
+            return;
+        }
         this.playSpeech(this.fallbackMessage, audioConfig, false, playbackSession);
     }
 
     playSpeech(text, audioConfig = {}, isSsml, playbackSession) {
+        if (!this.isSpeechReallyUsable()) {
+            this.updateStatus('Sprachausgabe nicht unterstützt');
+            if (this.isCurrentPlaybackSession(playbackSession)) {
+                this.onEnded?.();
+            }
+            return;
+        }
+
         const utterance = new SpeechSynthesisUtterance();
         utterance.text = isSsml ? ssmlToSpeechText(text) : text;
         utterance.lang = audioConfig.lang || 'de-DE';


### PR DESCRIPTION
### Motivation
- On manchen Android-Geräten (z. B. Huawei) existiert `window.speechSynthesis`, ist aber praktisch unbrauchbar, wodurch TTS-Pfade Fehler auslösen oder die Wiedergabe hängen bleibt.
- Die Änderung soll verhindern, dass die Anwendung weiterhin TTS versucht, wenn die SpeechSynthesis-API zwar vorhanden, aber nicht wirklich funktionsfähig ist.

### Description
- Guarded `pause()` und `resume()` mit optionaler Verkettung (`this.synthesis?....`) um Laufzeitfehler zu vermeiden, wenn `speechSynthesis` fehlt oder undefiniert ist.
- Verwendet `isSpeechReallyUsable()` als zusätzliche Prüfung in `playFallbackMessage()` und `playSpeech()` und beendet die TTS-Pfade frühzeitig mit Status-Updates und `onEnded`-Aufruf, wenn TTS nicht nutzbar ist.
- Aktualisierte die Nutzerwarnung in `checkAudioSupport()` um nicht mehr pauschal `Chrome` zu empfehlen, sondern auf Audio-Dateien bzw. ein Gerät mit funktionierender SpeechSynthesis hinzuweisen.

### Testing
- Statische Syntaxprüfung mit `node --check src/audio.js` und `node --check src/app.js` wurde ausgeführt und zeigte keine Fehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8a81023c832aa2245644fdbd5681)