### PR TITLE
Scroll to slide stage start when closing transcript panel

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -496,7 +496,7 @@ function setTranscriptPanelVisibility(isVisible) {
 function hideTranscriptPanel() {
     setTranscriptPanelVisibility(false);
     clearTranscriptPanelContent();
-    window.scrollTo(0, 0);
+    elements.slideStage?.scrollIntoView({behavior: 'auto', block: 'start'});
 }
 
 function clearTranscriptPanelContent() {


### PR DESCRIPTION
### Motivation
- Beim Schließen des Transcript-Panels (z. B. beim Folienwechsel) wurde bisher mit `window.scrollTo(0, 0)` immer ganz nach oben gescrollt, was auf Mobilgeräten die Nutzererfahrung verschlechtert; Ziel ist, Nutzer direkt an den Beginn der aktuellen Folie zu bringen.

### Description
- Ersetze in `hideTranscriptPanel()` das `window.scrollTo(0, 0)` durch `elements.slideStage?.scrollIntoView({behavior: 'auto', block: 'start'})` in `src/app.js` damit beim Schließen des Panels zum Anfang der Foliendarstellung gescrollt wird.

### Testing
- Führte `node --check src/app.js` aus und die statische Syntaxprüfung war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8d935cac832aa34343df465ee9c9)