### PR TITLE
Adjust mobile player layout and move error messages below controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
             <dt>Quelle</dt><dd id="source-kind">–</dd>
             <dt>Audio</dt><dd id="audio-status">Gestoppt</dd>
           </dl>
-          <div id="error-box" class="error-box hidden" role="alert"></div>
         </section>
 
         <section class="panel">
@@ -132,6 +131,7 @@
             </label>
           </div>
         </header>
+        <div id="error-box" class="error-box error-box--stage hidden" role="alert"></div>
 
         <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
           <h3>Audioinhalt der aktuellen Folie</h3>

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,14 +46,15 @@ code {
 }
 
 .stage {
-    display: grid;
-    grid-template-rows: auto 1fr;
+    display: flex;
+    flex-direction: column;
     min-height: 100vh;
 }
 
 .toolbar {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     gap: 16px;
     padding: 12px 18px;
     border-bottom: 1px solid var(--border);
@@ -258,6 +259,10 @@ input[type="url"] {
     white-space: pre-line;
 }
 
+.error-box--stage {
+    margin: 12px 18px 0;
+}
+
 .slide-list {
     margin: 0;
     padding-left: 20px;
@@ -283,6 +288,7 @@ input[type="url"] {
     display: flex;
     align-items: stretch;
     justify-content: center;
+    flex: 1;
 }
 
 .slide-card {
@@ -352,6 +358,25 @@ input[type="url"] {
     .slide-card {
         padding: 28px;
         min-height: auto;
+    }
+}
+
+@media (max-width: 820px) {
+    .toolbar {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    .toolbar-group {
+        width: 100%;
+    }
+
+    .toolbar-group--primary {
+        width: 100%;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 2px;
     }
 }
 


### PR DESCRIPTION
### Motivation
- On narrow (phone) viewports the right-side player controls were cut off and runtime errors were placed in the sidebar, so errors and some controls are not visible to the user.

### Description
- Moved the runtime error alert element from the sidebar status panel into the stage directly below the toolbar by relocating `#error-box` in `index.html`.
- Converted the stage layout to a vertical flex container by updating `.stage` to `display: flex; flex-direction: column;` so the slide area continues to fill remaining space and can shrink/grow correctly.
- Added an `.error-box--stage` class and adjusted `.slide-stage` to `flex: 1` so the error row sits between the toolbar and the slides without reducing the slide area.
- Added a mobile media query (`@media (max-width: 820px)`) that makes the `.toolbar` wrap to multiple rows, sets `.toolbar-group` full width, and makes `.toolbar-group--primary` horizontally scrollable to keep primary transport controls visible.

### Testing
- Ran `git diff --check` which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9042df78832a9b26b04342ef2e90)