### PR TITLE
Improve slide transition bell into fuller yoga gong

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,10 +6,10 @@ import {loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote} from './load
 const state = createInitialState();
 let slideAdvanceTimer = null;
 let slideChangeCueAudioContext = null;
-const SLIDE_CHANGE_BELL_VOLUME = 5.0;
-const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.045;
-const SLIDE_CHANGE_BELL_DECAY_SECONDS = 1.8;
-const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.5;
+const SLIDE_CHANGE_BELL_VOLUME = 3.6;
+const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.025;
+const SLIDE_CHANGE_BELL_DECAY_SECONDS = 3.2;
+const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const TRANSITION_UNLOCK_TIMEOUT_MS = 10_000;
 let isSlideTransitionInProgress = false;
 let transitionUnlockTimer = null;
@@ -311,36 +311,103 @@ function playSlideChangeCue() {
         const attackEnd = now + SLIDE_CHANGE_BELL_STRIKE_SECONDS;
         const releaseEnd = attackEnd + SLIDE_CHANGE_BELL_DECAY_SECONDS;
         const masterGain = context.createGain();
-        const bellVoices = [
-            {frequency: 110, level: 1.0, type: 'sine', detune: -3},
-            {frequency: 165, level: 0.7, type: 'triangle', detune: 2},
-            {frequency: 220, level: 0.45, type: 'sine', detune: -1},
-            {frequency: 277, level: 0.3, type: 'sine', detune: 1},
-            {frequency: 330, level: 0.2, type: 'triangle', detune: 0},
+        const bodyFilter = context.createBiquadFilter();
+        bodyFilter.type = 'bandpass';
+        bodyFilter.frequency.setValueAtTime(165, now);
+        bodyFilter.Q.setValueAtTime(0.8, now);
+
+        const shimmerFilter = context.createBiquadFilter();
+        shimmerFilter.type = 'highshelf';
+        shimmerFilter.frequency.setValueAtTime(1800, now);
+        shimmerFilter.gain.setValueAtTime(6, now);
+
+        const lowBloom = context.createGain();
+        lowBloom.gain.setValueAtTime(1.0, now);
+
+        const gongPartials = [
+            {frequency: 82.4, level: 1.0, type: 'sine', detune: -1.4, ring: 1.1},
+            {frequency: 109.8, level: 0.85, type: 'triangle', detune: 1.1, ring: 1.25},
+            {frequency: 146.8, level: 0.55, type: 'sine', detune: -0.9, ring: 1.4},
+            {frequency: 197.5, level: 0.34, type: 'triangle', detune: 0.7, ring: 1.7},
+            {frequency: 247.0, level: 0.26, type: 'sine', detune: -0.4, ring: 1.9},
+            {frequency: 330.0, level: 0.14, type: 'triangle', detune: 0.3, ring: 2.2},
         ];
 
         masterGain.gain.setValueAtTime(0.0001, now);
         masterGain.gain.exponentialRampToValueAtTime(SLIDE_CHANGE_BELL_VOLUME, attackEnd);
         masterGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
+        bodyFilter.connect(shimmerFilter);
+        shimmerFilter.connect(masterGain);
+        lowBloom.connect(masterGain);
         masterGain.connect(context.destination);
 
-        bellVoices.forEach(({frequency, level, type, detune}) => {
+        gongPartials.forEach(({frequency, level, type, detune, ring}) => {
             const oscillator = context.createOscillator();
             const voiceGain = context.createGain();
+            const slightVibrato = context.createOscillator();
+            const vibratoGain = context.createGain();
+
             oscillator.type = type;
             oscillator.frequency.setValueAtTime(frequency, now);
             oscillator.detune.setValueAtTime(detune, now);
-            oscillator.detune.linearRampToValueAtTime(detune * 0.4, releaseEnd);
+            oscillator.detune.linearRampToValueAtTime(detune * 0.3, releaseEnd);
 
             voiceGain.gain.setValueAtTime(Math.max(0.0001, level * 0.001), now);
             voiceGain.gain.exponentialRampToValueAtTime(Math.max(0.0001, level), attackEnd);
-            voiceGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
+            voiceGain.gain.exponentialRampToValueAtTime(0.0001, attackEnd + (SLIDE_CHANGE_BELL_DECAY_SECONDS * ring));
+
+            slightVibrato.type = 'sine';
+            slightVibrato.frequency.setValueAtTime(5.3, now);
+            vibratoGain.gain.setValueAtTime(0.35, now);
+            vibratoGain.gain.exponentialRampToValueAtTime(0.01, releaseEnd);
+            slightVibrato.connect(vibratoGain);
+            vibratoGain.connect(oscillator.detune);
 
             oscillator.connect(voiceGain);
-            voiceGain.connect(masterGain);
+            voiceGain.connect(bodyFilter);
             oscillator.start(now);
-            oscillator.stop(releaseEnd + 0.05);
+            slightVibrato.start(now);
+            oscillator.stop(releaseEnd + 0.25);
+            slightVibrato.stop(releaseEnd + 0.25);
         });
+
+        const strikeDurationSeconds = 0.03;
+        const strikeBuffer = context.createBuffer(1, Math.max(1, Math.floor(strikeDurationSeconds * context.sampleRate)), context.sampleRate);
+        const strikeChannel = strikeBuffer.getChannelData(0);
+        for (let sampleIndex = 0; sampleIndex < strikeChannel.length; sampleIndex += 1) {
+            const envelope = 1 - (sampleIndex / strikeChannel.length);
+            strikeChannel[sampleIndex] = (Math.random() * 2 - 1) * envelope;
+        }
+
+        const strikeNoise = context.createBufferSource();
+        strikeNoise.buffer = strikeBuffer;
+        const strikeFilter = context.createBiquadFilter();
+        strikeFilter.type = 'bandpass';
+        strikeFilter.frequency.setValueAtTime(1100, now);
+        strikeFilter.Q.setValueAtTime(2.5, now);
+        const strikeGain = context.createGain();
+        strikeGain.gain.setValueAtTime(0.0001, now);
+        strikeGain.gain.exponentialRampToValueAtTime(0.17, now + 0.006);
+        strikeGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.12);
+
+        strikeNoise.connect(strikeFilter);
+        strikeFilter.connect(strikeGain);
+        strikeGain.connect(shimmerFilter);
+        strikeNoise.start(now);
+
+        const subBoom = context.createOscillator();
+        subBoom.type = 'sine';
+        subBoom.frequency.setValueAtTime(74, now);
+        subBoom.frequency.exponentialRampToValueAtTime(52, now + 0.42);
+        const subBoomGain = context.createGain();
+        subBoomGain.gain.setValueAtTime(0.0001, now);
+        subBoomGain.gain.exponentialRampToValueAtTime(0.4, now + 0.02);
+        subBoomGain.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
+        subBoom.connect(subBoomGain);
+        subBoomGain.connect(lowBloom);
+        subBoom.start(now);
+        subBoom.stop(now + 1.2);
+
         return SLIDE_CHANGE_BELL_STRIKE_SECONDS + SLIDE_CHANGE_BELL_DECAY_SECONDS;
     } catch (error) {
         console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);


### PR DESCRIPTION
### Motivation
- Replace the short, bright slide-change bell with a warmer, more voluminous yoga-gong-style cue to give slide transitions more body and presence.
- Emulate realistic gong character (mallet strike, inharmonic partials, long resonant tail and subtle motion) rather than a simple multi-oscillator beep.

### Description
- Adjusted timing and level constants (`SLIDE_CHANGE_BELL_VOLUME`, `SLIDE_CHANGE_BELL_STRIKE_SECONDS`, `SLIDE_CHANGE_BELL_DECAY_SECONDS`, `SLIDE_CHANGE_BELL_PAUSE_SECONDS`) to favor a faster strike and much longer decay in `src/app.js`.
- Reworked `playSlideChangeCue` in `src/app.js` to replace the simple `bellVoices` list with layered `gongPartials`, a `body` bandpass and a `shimmer` highshelf filter, routed into a `masterGain` for a fuller timbre.
- Added a short filtered noise transient (mallet strike) and a low-frequency `subBoom` oscillator to simulate impact and a resonant low bloom, and introduced slight vibrato/detune ramps per partial for natural motion.
- Kept existing fallback and AudioContext handling, and returned the cue duration as before so slide-transition timing remains consistent.

### Testing
- Ran `node --check src/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de98af686c832a8b1a44cbf7b508fd)