### PR TITLE
Behebe Swipe-Richtung und extrahiere Hilfs-Module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,21 @@ import {createInitialState} from './state.js';
 import {renderSlideContent} from './parser.js';
 import {AudioController} from './audio.js';
 import {loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote} from './loaders.js';
+import {
+    canPlayInAudioElement,
+    inferAudioType,
+    isPlayableAudioType,
+    isTextAudioType,
+    preserveStructuredText,
+    ssmlToDisplayText,
+} from './transcript.js';
+import {
+    createSwipeState,
+    finishSwipe,
+    resetSwipeState,
+    startSwipeTracking,
+    updateSwipeTracking,
+} from './swipe.js';
 
 const state = createInitialState();
 let slideAdvanceTimer = null;
@@ -11,17 +26,9 @@ const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.025;
 const SLIDE_CHANGE_BELL_DECAY_SECONDS = 3.2;
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const TRANSITION_UNLOCK_TIMEOUT_MS = 10_000;
-const SWIPE_MIN_HORIZONTAL_DISTANCE_PX = 45;
-const SWIPE_MAX_VERTICAL_DRIFT_PX = 120;
 let isSlideTransitionInProgress = false;
 let transitionUnlockTimer = null;
-const swipeState = {
-    startX: 0,
-    startY: 0,
-    lastX: 0,
-    lastY: 0,
-    tracking: false,
-};
+const swipeState = createSwipeState();
 
 const elements = {
     deckTitle: document.querySelector('#deck-title'),
@@ -161,24 +168,22 @@ function bindEvents() {
     elements.slideStage.addEventListener('touchend', (event) => {
         void handleTouchEnd(event);
     }, {passive: true});
-    elements.slideStage.addEventListener('touchcancel', resetSwipeState, {passive: true});
+    elements.slideStage.addEventListener('touchcancel', () => {
+        resetSwipeState(swipeState);
+    }, {passive: true});
 }
 
 function handleTouchStart(event) {
     if (event.touches.length !== 1) {
-        resetSwipeState();
+        resetSwipeState(swipeState);
         return;
     }
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLButtonElement) {
-        resetSwipeState();
+        resetSwipeState(swipeState);
         return;
     }
     const touch = event.touches[0];
-    swipeState.startX = touch.clientX;
-    swipeState.startY = touch.clientY;
-    swipeState.lastX = touch.clientX;
-    swipeState.lastY = touch.clientY;
-    swipeState.tracking = true;
+    startSwipeTracking(swipeState, touch);
 }
 
 function handleTouchMove(event) {
@@ -186,45 +191,29 @@ function handleTouchMove(event) {
         return;
     }
     const touch = event.touches[0];
-    swipeState.lastX = touch.clientX;
-    swipeState.lastY = touch.clientY;
+    updateSwipeTracking(swipeState, touch);
 }
 
 async function handleTouchEnd(event) {
     if (!swipeState.tracking || !state.deck || isSlideTransitionInProgress) {
-        resetSwipeState();
+        resetSwipeState(swipeState);
         return;
     }
 
-    const changedTouch = event.changedTouches?.[0];
-    const endX = changedTouch?.clientX ?? swipeState.lastX;
-    const endY = changedTouch?.clientY ?? swipeState.lastY;
-    const horizontalDistance = endX - swipeState.startX;
-    const verticalDistance = endY - swipeState.startY;
-    const isHorizontalSwipe = Math.abs(horizontalDistance) >= SWIPE_MIN_HORIZONTAL_DISTANCE_PX
-        && Math.abs(verticalDistance) <= SWIPE_MAX_VERTICAL_DRIFT_PX
-        && Math.abs(horizontalDistance) > Math.abs(verticalDistance);
+    const {isHorizontalSwipe, horizontalDistance} = finishSwipe(swipeState, event.changedTouches?.[0]);
 
-    resetSwipeState();
+    resetSwipeState(swipeState);
 
     if (!isHorizontalSwipe) {
         return;
     }
 
     if (horizontalDistance < 0) {
-        await goToSlide(state.currentIndex - 1);
+        await goToSlide(state.currentIndex + 1);
         return;
     }
 
-    await goToSlide(state.currentIndex + 1);
-}
-
-function resetSwipeState() {
-    swipeState.startX = 0;
-    swipeState.startY = 0;
-    swipeState.lastX = 0;
-    swipeState.lastY = 0;
-    swipeState.tracking = false;
+    await goToSlide(state.currentIndex - 1);
 }
 
 function clearSlideAdvanceTimer() {
@@ -751,123 +740,4 @@ function escapeHtml(value) {
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", '&#39;');
-}
-
-function inferAudioType(audioConfig = {}) {
-    const explicitType = String(audioConfig.type || '').trim().toLowerCase();
-    if (explicitType) {
-        return explicitType;
-    }
-
-    const src = String(audioConfig.src || '').trim();
-    if (!src) {
-        return '';
-    }
-
-    return src
-        .split('#', 1)[0]
-        .split('?', 1)[0]
-        .split('.')
-        .pop()
-        ?.toLowerCase();
-}
-
-function ssmlToDisplayText(ssml) {
-    const normalized = String(ssml).replace(/\r\n?/g, '\n');
-    const withStructure = normalized
-        .replace(/<\s*break\b[^>]*\/?>/gi, '\n')
-        .replace(/<\s*br\s*\/?>/gi, '\n')
-        .replace(/<\s*\/\s*(p|div|section|article|li|ul|ol|h1|h2|h3|h4|h5|h6)\s*>/gi, '\n')
-        .replace(/<\s*\/\s*(s|sentence)\s*>/gi, '\n')
-        .replace(/<\s*\/\s*(speak|paragraph)\s*>/gi, '\n\n');
-
-    const withoutTags = withStructure.replace(/<[^>]+>/g, '');
-    const decoded = decodeSimpleXmlEntities(withoutTags);
-
-    return preserveStructuredText(decoded);
-}
-
-function isTextAudioType(audioType) {
-    return audioType === 'txt' || audioType === 'ssml';
-}
-
-function isPlayableAudioType(audioType, sourcePath = '') {
-    if (audioType && !isTextAudioType(audioType)) {
-        return true;
-    }
-
-    const extension = String(sourcePath)
-        .split('#', 1)[0]
-        .split('?', 1)[0]
-        .split('.')
-        .pop()
-        ?.toLowerCase();
-
-    return ['mp3', 'm4a', 'aac', 'wav', 'ogg', 'oga', 'opus', 'flac', 'webm', 'mp4'].includes(extension || '');
-}
-
-function preserveStructuredText(text) {
-    return String(text)
-        .replace(/\r\n?/g, '\n')
-        .replace(/[ \t]+\n/g, '\n')
-        .replace(/\n{3,}/g, '\n\n')
-        .trim();
-}
-
-function decodeSimpleXmlEntities(text) {
-    return String(text)
-        .replaceAll('&nbsp;', ' ')
-        .replaceAll('&amp;', '&')
-        .replaceAll('&lt;', '<')
-        .replaceAll('&gt;', '>')
-        .replaceAll('&quot;', '"')
-        .replaceAll('&apos;', "'");
-}
-
-function canPlayInAudioElement(audioElement, audioType, sourcePath) {
-    const mimeType = inferMimeType(audioType, sourcePath);
-    if (!mimeType) {
-        return false;
-    }
-    return audioElement.canPlayType(mimeType) !== '';
-}
-
-function inferMimeType(audioType, sourcePath) {
-    const normalizedType = String(audioType || '').toLowerCase();
-    if (normalizedType === 'ssml') return 'application/ssml+xml';
-    if (normalizedType === 'txt') return 'text/plain';
-    if (normalizedType === 'mp3') return 'audio/mpeg';
-    if (normalizedType === 'wav') return 'audio/wav';
-    if (normalizedType === 'ogg') return 'audio/ogg';
-    if (normalizedType === 'oga') return 'audio/ogg';
-    if (normalizedType === 'opus') return 'audio/ogg; codecs=opus';
-    if (normalizedType === 'm4a') return 'audio/mp4';
-    if (normalizedType === 'aac') return 'audio/aac';
-    if (normalizedType === 'flac') return 'audio/flac';
-    if (normalizedType === 'webm') return 'audio/webm';
-    if (normalizedType === 'mp4') return 'audio/mp4';
-
-    const extension = String(sourcePath)
-        .split('#', 1)[0]
-        .split('?', 1)[0]
-        .split('.')
-        .pop()
-        ?.toLowerCase();
-
-    const extensionToMime = {
-        ssml: 'application/ssml+xml',
-        txt: 'text/plain',
-        mp3: 'audio/mpeg',
-        wav: 'audio/wav',
-        ogg: 'audio/ogg',
-        oga: 'audio/ogg',
-        opus: 'audio/ogg; codecs=opus',
-        m4a: 'audio/mp4',
-        aac: 'audio/aac',
-        flac: 'audio/flac',
-        webm: 'audio/webm',
-        mp4: 'audio/mp4',
-    };
-
-    return extensionToMime[extension] || '';
 }

--- a/src/swipe.js
+++ b/src/swipe.js
@@ -1,0 +1,48 @@
+export const SWIPE_MIN_HORIZONTAL_DISTANCE_PX = 45;
+export const SWIPE_MAX_VERTICAL_DRIFT_PX = 120;
+
+export function createSwipeState() {
+    return {
+        startX: 0,
+        startY: 0,
+        lastX: 0,
+        lastY: 0,
+        tracking: false,
+    };
+}
+
+export function startSwipeTracking(state, touch) {
+    state.startX = touch.clientX;
+    state.startY = touch.clientY;
+    state.lastX = touch.clientX;
+    state.lastY = touch.clientY;
+    state.tracking = true;
+}
+
+export function updateSwipeTracking(state, touch) {
+    state.lastX = touch.clientX;
+    state.lastY = touch.clientY;
+}
+
+export function finishSwipe(state, changedTouch) {
+    const endX = changedTouch?.clientX ?? state.lastX;
+    const endY = changedTouch?.clientY ?? state.lastY;
+    const horizontalDistance = endX - state.startX;
+    const verticalDistance = endY - state.startY;
+    const isHorizontalSwipe = Math.abs(horizontalDistance) >= SWIPE_MIN_HORIZONTAL_DISTANCE_PX
+        && Math.abs(verticalDistance) <= SWIPE_MAX_VERTICAL_DRIFT_PX
+        && Math.abs(horizontalDistance) > Math.abs(verticalDistance);
+
+    return {
+        isHorizontalSwipe,
+        horizontalDistance,
+    };
+}
+
+export function resetSwipeState(state) {
+    state.startX = 0;
+    state.startY = 0;
+    state.lastX = 0;
+    state.lastY = 0;
+    state.tracking = false;
+}

--- a/src/transcript.js
+++ b/src/transcript.js
@@ -1,0 +1,118 @@
+export function inferAudioType(audioConfig = {}) {
+    const explicitType = String(audioConfig.type || '').trim().toLowerCase();
+    if (explicitType) {
+        return explicitType;
+    }
+
+    const src = String(audioConfig.src || '').trim();
+    if (!src) {
+        return '';
+    }
+
+    return src
+        .split('#', 1)[0]
+        .split('?', 1)[0]
+        .split('.')
+        .pop()
+        ?.toLowerCase();
+}
+
+export function ssmlToDisplayText(ssml) {
+    const normalized = String(ssml).replace(/\r\n?/g, '\n');
+    const withStructure = normalized
+        .replace(/<\s*break\b[^>]*\/?>/gi, '\n')
+        .replace(/<\s*br\s*\/?>/gi, '\n')
+        .replace(/<\s*\/\s*(p|div|section|article|li|ul|ol|h1|h2|h3|h4|h5|h6)\s*>/gi, '\n')
+        .replace(/<\s*\/\s*(s|sentence)\s*>/gi, '\n')
+        .replace(/<\s*\/\s*(speak|paragraph)\s*>/gi, '\n\n');
+
+    const withoutTags = withStructure.replace(/<[^>]+>/g, '');
+    const decoded = decodeSimpleXmlEntities(withoutTags);
+
+    return preserveStructuredText(decoded);
+}
+
+export function isTextAudioType(audioType) {
+    return audioType === 'txt' || audioType === 'ssml';
+}
+
+export function isPlayableAudioType(audioType, sourcePath = '') {
+    if (audioType && !isTextAudioType(audioType)) {
+        return true;
+    }
+
+    const extension = String(sourcePath)
+        .split('#', 1)[0]
+        .split('?', 1)[0]
+        .split('.')
+        .pop()
+        ?.toLowerCase();
+
+    return ['mp3', 'm4a', 'aac', 'wav', 'ogg', 'oga', 'opus', 'flac', 'webm', 'mp4'].includes(extension || '');
+}
+
+export function preserveStructuredText(text) {
+    return String(text)
+        .replace(/\r\n?/g, '\n')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+export function canPlayInAudioElement(audioElement, audioType, sourcePath) {
+    const mimeType = inferMimeType(audioType, sourcePath);
+    if (!mimeType) {
+        return false;
+    }
+    return audioElement.canPlayType(mimeType) !== '';
+}
+
+function decodeSimpleXmlEntities(text) {
+    return String(text)
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&apos;', "'");
+}
+
+function inferMimeType(audioType, sourcePath) {
+    const normalizedType = String(audioType || '').toLowerCase();
+    if (normalizedType === 'ssml') return 'application/ssml+xml';
+    if (normalizedType === 'txt') return 'text/plain';
+    if (normalizedType === 'mp3') return 'audio/mpeg';
+    if (normalizedType === 'wav') return 'audio/wav';
+    if (normalizedType === 'ogg') return 'audio/ogg';
+    if (normalizedType === 'oga') return 'audio/ogg';
+    if (normalizedType === 'opus') return 'audio/ogg; codecs=opus';
+    if (normalizedType === 'm4a') return 'audio/mp4';
+    if (normalizedType === 'aac') return 'audio/aac';
+    if (normalizedType === 'flac') return 'audio/flac';
+    if (normalizedType === 'webm') return 'audio/webm';
+    if (normalizedType === 'mp4') return 'audio/mp4';
+
+    const extension = String(sourcePath)
+        .split('#', 1)[0]
+        .split('?', 1)[0]
+        .split('.')
+        .pop()
+        ?.toLowerCase();
+
+    const extensionToMime = {
+        ssml: 'application/ssml+xml',
+        txt: 'text/plain',
+        mp3: 'audio/mpeg',
+        wav: 'audio/wav',
+        ogg: 'audio/ogg',
+        oga: 'audio/ogg',
+        opus: 'audio/ogg; codecs=opus',
+        m4a: 'audio/mp4',
+        aac: 'audio/aac',
+        flac: 'audio/flac',
+        webm: 'audio/webm',
+        mp4: 'audio/mp4',
+    };
+
+    return extensionToMime[extension] || '';
+}


### PR DESCRIPTION
### Motivation
- Ein Swipe-Regression-Fehler verhinderte das initiale Wechseln von Folie 1 zur nächsten Folie wegen vertauschter Richtungslogik in den Touch-Handlern.
- `src/app.js` war sehr groß und enthielt verschiedene Hilfsfunktionen, die thematisch ausgelagert werden sollten, um Wartbarkeit und Lesbarkeit zu verbessern.

### Description
- Korrigiert die Swipe-Richtung in `handleTouchEnd` so, dass ein Left-Swipe zur nächsten Folie (`currentIndex + 1`) und ein Right-Swipe zur vorherigen Folie (`currentIndex - 1`) navigiert.
- Extrahiert die Swipe-Gesten-Logik in `src/swipe.js` und ersetzt inline-State-Manipulation durch die Funktionen `createSwipeState`, `startSwipeTracking`, `updateSwipeTracking`, `finishSwipe` und `resetSwipeState` in `src/app.js`.
- Verschiebt Transcript- und Audio-Typ-Helfer in `src/transcript.js` (z. B. `inferAudioType`, `ssmlToDisplayText`, `isPlayableAudioType`, `canPlayInAudioElement`) und importiert diese in `src/app.js`.
- Passt den `touchcancel`-Handler an, damit `resetSwipeState(swipeState)` explizit auf den aktuellen Swipe-State angewendet wird, sodass das Tracking zuverlässig zurückgesetzt wird.

### Testing
- `node --check src/app.js` — erfolgreich.
- `node --check src/transcript.js` — erfolgreich.
- `node --check src/swipe.js` — erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df33352cf4832a9c0731b859d4a90c)