### PR TITLE
Extract gong synthesis into dedicated module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,12 @@ import {renderSlideContent} from './parser.js';
 import {AudioController} from './audio.js';
 import {loadDeckFromDirectory, loadDeckFromZip, loadDeckFromRemote} from './loaders.js';
 import {
+    SLIDE_CHANGE_BELL_DECAY_SECONDS,
+    SLIDE_CHANGE_BELL_STRIKE_SECONDS,
+    SLIDE_CHANGE_BELL_VOLUME,
+    playSlideChangeGong,
+} from './gong.js';
+import {
     canPlayInAudioElement,
     inferAudioType,
     isPlayableAudioType,
@@ -21,9 +27,6 @@ import {
 const state = createInitialState();
 let slideAdvanceTimer = null;
 let slideChangeCueAudioContext = null;
-const SLIDE_CHANGE_BELL_VOLUME = 3.6;
-const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.025;
-const SLIDE_CHANGE_BELL_DECAY_SECONDS = 3.2;
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const TRANSITION_UNLOCK_TIMEOUT_MS = 10_000;
 let isSlideTransitionInProgress = false;
@@ -375,108 +378,11 @@ function playSlideChangeCue() {
             });
         }
 
-        const now = context.currentTime;
-        const attackEnd = now + SLIDE_CHANGE_BELL_STRIKE_SECONDS;
-        const releaseEnd = attackEnd + SLIDE_CHANGE_BELL_DECAY_SECONDS;
-        const masterGain = context.createGain();
-        const bodyFilter = context.createBiquadFilter();
-        bodyFilter.type = 'bandpass';
-        bodyFilter.frequency.setValueAtTime(165, now);
-        bodyFilter.Q.setValueAtTime(0.8, now);
-
-        const shimmerFilter = context.createBiquadFilter();
-        shimmerFilter.type = 'highshelf';
-        shimmerFilter.frequency.setValueAtTime(1800, now);
-        shimmerFilter.gain.setValueAtTime(6, now);
-
-        const lowBloom = context.createGain();
-        lowBloom.gain.setValueAtTime(1.0, now);
-
-        const gongPartials = [
-            {frequency: 82.4, level: 1.0, type: 'sine', detune: -1.4, ring: 1.1},
-            {frequency: 109.8, level: 0.85, type: 'triangle', detune: 1.1, ring: 1.25},
-            {frequency: 146.8, level: 0.55, type: 'sine', detune: -0.9, ring: 1.4},
-            {frequency: 197.5, level: 0.34, type: 'triangle', detune: 0.7, ring: 1.7},
-            {frequency: 247.0, level: 0.26, type: 'sine', detune: -0.4, ring: 1.9},
-            {frequency: 330.0, level: 0.14, type: 'triangle', detune: 0.3, ring: 2.2},
-        ];
-
-        masterGain.gain.setValueAtTime(0.0001, now);
-        masterGain.gain.exponentialRampToValueAtTime(SLIDE_CHANGE_BELL_VOLUME, attackEnd);
-        masterGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
-        bodyFilter.connect(shimmerFilter);
-        shimmerFilter.connect(masterGain);
-        lowBloom.connect(masterGain);
-        masterGain.connect(context.destination);
-
-        gongPartials.forEach(({frequency, level, type, detune, ring}) => {
-            const oscillator = context.createOscillator();
-            const voiceGain = context.createGain();
-            const slightVibrato = context.createOscillator();
-            const vibratoGain = context.createGain();
-
-            oscillator.type = type;
-            oscillator.frequency.setValueAtTime(frequency, now);
-            oscillator.detune.setValueAtTime(detune, now);
-            oscillator.detune.linearRampToValueAtTime(detune * 0.3, releaseEnd);
-
-            voiceGain.gain.setValueAtTime(Math.max(0.0001, level * 0.001), now);
-            voiceGain.gain.exponentialRampToValueAtTime(Math.max(0.0001, level), attackEnd);
-            voiceGain.gain.exponentialRampToValueAtTime(0.0001, attackEnd + (SLIDE_CHANGE_BELL_DECAY_SECONDS * ring));
-
-            slightVibrato.type = 'sine';
-            slightVibrato.frequency.setValueAtTime(5.3, now);
-            vibratoGain.gain.setValueAtTime(0.35, now);
-            vibratoGain.gain.exponentialRampToValueAtTime(0.01, releaseEnd);
-            slightVibrato.connect(vibratoGain);
-            vibratoGain.connect(oscillator.detune);
-
-            oscillator.connect(voiceGain);
-            voiceGain.connect(bodyFilter);
-            oscillator.start(now);
-            slightVibrato.start(now);
-            oscillator.stop(releaseEnd + 0.25);
-            slightVibrato.stop(releaseEnd + 0.25);
+        return playSlideChangeGong(context, {
+            volume: SLIDE_CHANGE_BELL_VOLUME,
+            strikeSeconds: SLIDE_CHANGE_BELL_STRIKE_SECONDS,
+            decaySeconds: SLIDE_CHANGE_BELL_DECAY_SECONDS,
         });
-
-        const strikeDurationSeconds = 0.03;
-        const strikeBuffer = context.createBuffer(1, Math.max(1, Math.floor(strikeDurationSeconds * context.sampleRate)), context.sampleRate);
-        const strikeChannel = strikeBuffer.getChannelData(0);
-        for (let sampleIndex = 0; sampleIndex < strikeChannel.length; sampleIndex += 1) {
-            const envelope = 1 - (sampleIndex / strikeChannel.length);
-            strikeChannel[sampleIndex] = (Math.random() * 2 - 1) * envelope;
-        }
-
-        const strikeNoise = context.createBufferSource();
-        strikeNoise.buffer = strikeBuffer;
-        const strikeFilter = context.createBiquadFilter();
-        strikeFilter.type = 'bandpass';
-        strikeFilter.frequency.setValueAtTime(1100, now);
-        strikeFilter.Q.setValueAtTime(2.5, now);
-        const strikeGain = context.createGain();
-        strikeGain.gain.setValueAtTime(0.0001, now);
-        strikeGain.gain.exponentialRampToValueAtTime(0.17, now + 0.006);
-        strikeGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.12);
-
-        strikeNoise.connect(strikeFilter);
-        strikeFilter.connect(strikeGain);
-        strikeGain.connect(shimmerFilter);
-        strikeNoise.start(now);
-
-        const subBoom = context.createOscillator();
-        subBoom.type = 'sine';
-        subBoom.frequency.setValueAtTime(74, now);
-        subBoom.frequency.exponentialRampToValueAtTime(52, now + 0.42);
-        const subBoomGain = context.createGain();
-        subBoomGain.gain.setValueAtTime(0.0001, now);
-        subBoomGain.gain.exponentialRampToValueAtTime(0.4, now + 0.02);
-        subBoomGain.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
-        subBoom.connect(subBoomGain);
-        subBoomGain.connect(lowBloom);
-        subBoom.start(now);
-        subBoom.stop(now + 1.2);
-
-        return SLIDE_CHANGE_BELL_STRIKE_SECONDS + SLIDE_CHANGE_BELL_DECAY_SECONDS;
     } catch (error) {
         console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);
         return 0;

--- a/src/gong.js
+++ b/src/gong.js
@@ -1,0 +1,112 @@
+export const SLIDE_CHANGE_BELL_VOLUME = 3.6;
+export const SLIDE_CHANGE_BELL_STRIKE_SECONDS = 0.025;
+export const SLIDE_CHANGE_BELL_DECAY_SECONDS = 3.2;
+
+export function playSlideChangeGong(context, {
+    volume = SLIDE_CHANGE_BELL_VOLUME,
+    strikeSeconds = SLIDE_CHANGE_BELL_STRIKE_SECONDS,
+    decaySeconds = SLIDE_CHANGE_BELL_DECAY_SECONDS,
+} = {}) {
+    const now = context.currentTime;
+    const attackEnd = now + strikeSeconds;
+    const releaseEnd = attackEnd + decaySeconds;
+    const masterGain = context.createGain();
+    const bodyFilter = context.createBiquadFilter();
+    bodyFilter.type = 'bandpass';
+    bodyFilter.frequency.setValueAtTime(165, now);
+    bodyFilter.Q.setValueAtTime(0.8, now);
+
+    const shimmerFilter = context.createBiquadFilter();
+    shimmerFilter.type = 'highshelf';
+    shimmerFilter.frequency.setValueAtTime(1800, now);
+    shimmerFilter.gain.setValueAtTime(6, now);
+
+    const lowBloom = context.createGain();
+    lowBloom.gain.setValueAtTime(1.0, now);
+
+    const gongPartials = [
+        {frequency: 82.4, level: 1.0, type: 'sine', detune: -1.4, ring: 1.1},
+        {frequency: 109.8, level: 0.85, type: 'triangle', detune: 1.1, ring: 1.25},
+        {frequency: 146.8, level: 0.55, type: 'sine', detune: -0.9, ring: 1.4},
+        {frequency: 197.5, level: 0.34, type: 'triangle', detune: 0.7, ring: 1.7},
+        {frequency: 247.0, level: 0.26, type: 'sine', detune: -0.4, ring: 1.9},
+        {frequency: 330.0, level: 0.14, type: 'triangle', detune: 0.3, ring: 2.2},
+    ];
+
+    masterGain.gain.setValueAtTime(0.0001, now);
+    masterGain.gain.exponentialRampToValueAtTime(volume, attackEnd);
+    masterGain.gain.exponentialRampToValueAtTime(0.0001, releaseEnd);
+    bodyFilter.connect(shimmerFilter);
+    shimmerFilter.connect(masterGain);
+    lowBloom.connect(masterGain);
+    masterGain.connect(context.destination);
+
+    gongPartials.forEach(({frequency, level, type, detune, ring}) => {
+        const oscillator = context.createOscillator();
+        const voiceGain = context.createGain();
+        const slightVibrato = context.createOscillator();
+        const vibratoGain = context.createGain();
+
+        oscillator.type = type;
+        oscillator.frequency.setValueAtTime(frequency, now);
+        oscillator.detune.setValueAtTime(detune, now);
+        oscillator.detune.linearRampToValueAtTime(detune * 0.3, releaseEnd);
+
+        voiceGain.gain.setValueAtTime(Math.max(0.0001, level * 0.001), now);
+        voiceGain.gain.exponentialRampToValueAtTime(Math.max(0.0001, level), attackEnd);
+        voiceGain.gain.exponentialRampToValueAtTime(0.0001, attackEnd + (decaySeconds * ring));
+
+        slightVibrato.type = 'sine';
+        slightVibrato.frequency.setValueAtTime(5.3, now);
+        vibratoGain.gain.setValueAtTime(0.35, now);
+        vibratoGain.gain.exponentialRampToValueAtTime(0.01, releaseEnd);
+        slightVibrato.connect(vibratoGain);
+        vibratoGain.connect(oscillator.detune);
+
+        oscillator.connect(voiceGain);
+        voiceGain.connect(bodyFilter);
+        oscillator.start(now);
+        slightVibrato.start(now);
+        oscillator.stop(releaseEnd + 0.25);
+        slightVibrato.stop(releaseEnd + 0.25);
+    });
+
+    const strikeDurationSeconds = 0.03;
+    const strikeBuffer = context.createBuffer(1, Math.max(1, Math.floor(strikeDurationSeconds * context.sampleRate)), context.sampleRate);
+    const strikeChannel = strikeBuffer.getChannelData(0);
+    for (let sampleIndex = 0; sampleIndex < strikeChannel.length; sampleIndex += 1) {
+        const envelope = 1 - (sampleIndex / strikeChannel.length);
+        strikeChannel[sampleIndex] = (Math.random() * 2 - 1) * envelope;
+    }
+
+    const strikeNoise = context.createBufferSource();
+    strikeNoise.buffer = strikeBuffer;
+    const strikeFilter = context.createBiquadFilter();
+    strikeFilter.type = 'bandpass';
+    strikeFilter.frequency.setValueAtTime(1100, now);
+    strikeFilter.Q.setValueAtTime(2.5, now);
+    const strikeGain = context.createGain();
+    strikeGain.gain.setValueAtTime(0.0001, now);
+    strikeGain.gain.exponentialRampToValueAtTime(0.17, now + 0.006);
+    strikeGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.12);
+
+    strikeNoise.connect(strikeFilter);
+    strikeFilter.connect(strikeGain);
+    strikeGain.connect(shimmerFilter);
+    strikeNoise.start(now);
+
+    const subBoom = context.createOscillator();
+    subBoom.type = 'sine';
+    subBoom.frequency.setValueAtTime(74, now);
+    subBoom.frequency.exponentialRampToValueAtTime(52, now + 0.42);
+    const subBoomGain = context.createGain();
+    subBoomGain.gain.setValueAtTime(0.0001, now);
+    subBoomGain.gain.exponentialRampToValueAtTime(0.4, now + 0.02);
+    subBoomGain.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
+    subBoom.connect(subBoomGain);
+    subBoomGain.connect(lowBloom);
+    subBoom.start(now);
+    subBoom.stop(now + 1.2);
+
+    return strikeSeconds + decaySeconds;
+}


### PR DESCRIPTION
### Motivation
- Separate the slide-change gong synthesis from `src/app.js` to improve modularity and readability.
- Make the gong logic reusable and easier to test or tweak independently from the main application logic.
- Keep runtime behavior unchanged while reducing the size and responsibility of `src/app.js`.

### Description
- Added a new module `src/gong.js` that exports default gong constants and the function `playSlideChangeGong(context, options)` which implements the gong synthesis and returns its duration.
- Updated `src/app.js` to import `SLIDE_CHANGE_BELL_VOLUME`, `SLIDE_CHANGE_BELL_STRIKE_SECONDS`, `SLIDE_CHANGE_BELL_DECAY_SECONDS` and `playSlideChangeGong` from `src/gong.js` and removed the inline synthesis code.
- Replaced the former inline `playSlideChangeCue()` implementation to delegate sound generation to `playSlideChangeGong(...)` while preserving the returned duration and existing error handling.

### Testing
- Ran `node --check src/app.js` which succeeded.
- Ran `node --check src/gong.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbaa77c4c832a97815d16d2e3935a)