### PR TITLE
Make manual slide changes instant while preserving autoplay transition delay

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -401,8 +401,10 @@ async function goToSlide(index, options = {}) {
         clearSlideAdvanceTimer();
         resetTapState();
         await audioController.stop();
-        const bellDurationSeconds = playSlideChangeCue();
-        await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
+        if (options.autoplay) {
+            const bellDurationSeconds = playSlideChangeCue();
+            await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
+        }
         state.currentIndex = index;
         hideTranscriptPanel();
         refreshUi();


### PR DESCRIPTION
### Motivation
- Manual user-triggered slide changes (swipe, button, list navigation) should occur immediately while keeping the existing autoplay cue and pause behavior intact.

### Description
- Change `goToSlide` so the gong+pause (`playSlideChangeCue` + `delay`) runs only when `options.autoplay` is true, making manual navigation immediate while preserving the autoplay transition path.
- Preserve existing cleanup and safety behavior including `clearSlideAdvanceTimer()`, `resetTapState()`, `await audioController.stop()`, the transition lock/unlock flow, UI refresh, and rendering.

### Testing
- Ran `node --check src/app.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc1272668832a84343c85f29b5bf7)