### PR TITLE
Add live showtime countdown beside the goto button

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@
             <label for="goto-input">Gehe zu</label>
             <input id="goto-input" type="number" min="1" step="1" value="1">
             <button id="goto-btn" type="button">Los</button>
+            <output id="showtime-countdown" class="showtime-countdown is-safe" aria-live="polite">–</output>
             <label class="checkbox-inline">
               <input id="autoplay-next-checkbox" type="checkbox" checked>
               <span>Nächste Folie automatisch</span>

--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,7 @@ import {
 
 const state = createInitialState();
 let slideAdvanceTimer = null;
+let showtimeCountdownInterval = null;
 let slideChangeCueAudioContext = null;
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const DEFAULT_SLIDE_SHOWTIME_SECONDS = 10;
@@ -50,6 +51,7 @@ const elements = {
     slideList: document.querySelector('#slide-list'),
     slideStage: document.querySelector('#slide-stage'),
     gotoInput: document.querySelector('#goto-input'),
+    showtimeCountdown: document.querySelector('#showtime-countdown'),
     transcriptToggleBtn: document.querySelector('#transcript-toggle-btn'),
     transcriptPanel: document.querySelector('#transcript-panel'),
     transcriptHint: document.querySelector('#transcript-hint'),
@@ -262,6 +264,13 @@ function clearSlideAdvanceTimer() {
     }
 }
 
+function clearShowtimeCountdown() {
+    if (showtimeCountdownInterval) {
+        window.clearInterval(showtimeCountdownInterval);
+        showtimeCountdownInterval = null;
+    }
+}
+
 function resetTapState() {
     tapState.lastTapTimestamp = 0;
     tapState.lastTapX = 0;
@@ -312,6 +321,38 @@ function getSlideShowtimeSeconds(slide) {
         return DEFAULT_SLIDE_SHOWTIME_SECONDS;
     }
     return value;
+}
+
+function renderShowtimeCountdown(value) {
+    if (!elements.showtimeCountdown) {
+        return;
+    }
+
+    const safeValue = Math.max(0, Math.floor(value));
+    elements.showtimeCountdown.textContent = String(safeValue);
+    elements.showtimeCountdown.classList.toggle('is-safe', safeValue > 3);
+    elements.showtimeCountdown.classList.toggle('is-danger', safeValue <= 3);
+}
+
+function startShowtimeCountdown(slide) {
+    clearShowtimeCountdown();
+    if (!slide || !Number.isFinite(Number(slide.showtime)) || Number(slide.showtime) <= 0) {
+        if (elements.showtimeCountdown) {
+            elements.showtimeCountdown.textContent = '–';
+            elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+        }
+        return;
+    }
+
+    let remainingSeconds = getSlideShowtimeSeconds(slide);
+    renderShowtimeCountdown(remainingSeconds);
+    showtimeCountdownInterval = window.setInterval(() => {
+        remainingSeconds -= 1;
+        renderShowtimeCountdown(remainingSeconds);
+        if (remainingSeconds <= 0) {
+            clearShowtimeCountdown();
+        }
+    }, 1000);
 }
 
 function updateSlideAudioStatus(slide) {
@@ -375,6 +416,7 @@ async function initializeFromQueryParameters() {
 
 async function setDeck(deck) {
     clearSlideAdvanceTimer();
+    clearShowtimeCountdown();
     state.deck = deck;
     state.sourceKind = deck.sourceKind;
     state.currentIndex = 0;
@@ -399,6 +441,7 @@ async function goToSlide(index, options = {}) {
     beginSlideTransitionLock();
     try {
         clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
         resetTapState();
         await audioController.stop();
         if (options.autoplay) {
@@ -453,9 +496,14 @@ function delay(durationMs) {
 
 async function renderCurrentSlide() {
     clearSlideAdvanceTimer();
+    clearShowtimeCountdown();
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
         elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
+        if (elements.showtimeCountdown) {
+            elements.showtimeCountdown.textContent = '–';
+            elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+        }
         hideTranscriptPanel();
         return;
     }
@@ -476,6 +524,7 @@ async function renderCurrentSlide() {
   `;
 
     await hydrateAsyncAssets();
+    startShowtimeCountdown(slide);
 
     if (!slide.audio) {
         updateSlideAudioStatus(slide);

--- a/src/styles.css
+++ b/src/styles.css
@@ -178,6 +178,21 @@ button:disabled {
     flex-wrap: nowrap;
 }
 
+.showtime-countdown {
+    min-width: 2ch;
+    font-size: 1.4rem;
+    font-weight: 700;
+    text-align: center;
+}
+
+.showtime-countdown.is-safe {
+    color: #6ee7a8;
+}
+
+.showtime-countdown.is-danger {
+    color: #ff7b72;
+}
+
 input[type="url"],
 input[type="number"] {
     padding: 10px 12px;


### PR DESCRIPTION
### Motivation
- Show the slide's `showtime` next to the "Los" button as a live countdown so presenters can see remaining display time at a glance.
- Provide immediate visual feedback using color thresholds (green for safe time, red when time is low).
- Ensure countdowns don't leak across slide transitions or deck changes by cleaning up intervals.

### Description
- Added an `<output id="showtime-countdown">` element in the toolbar next to the `goto` button in `index.html` for the visible countdown.
- Implemented countdown logic in `src/app.js` including `showtimeCountdownInterval`, `clearShowtimeCountdown()`, `renderShowtimeCountdown()` and `startShowtimeCountdown()` and wired them to `renderCurrentSlide()`, `goToSlide()` and `setDeck()` so the timer starts/stops with slide rendering and transitions.
- Reused existing `getSlideShowtimeSeconds()` to determine initial values and applied threshold coloring by toggling `is-safe` when value &gt; 3 and `is-danger` when value <= 3.
- Added CSS rules in `src/styles.css` for `.showtime-countdown`, `.showtime-countdown.is-safe` and `.showtime-countdown.is-danger` to show size and green/red colors.

### Testing
- Ran `node --check src/app.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc6514754832aae6df18f30b6a553)