### PR TITLE
Sync auto-advance when toggling autoplay and rendering non-audio slides

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -145,6 +145,7 @@ function bindEvents() {
     });
     elements.autoplayNextCheckbox.addEventListener('change', () => {
         state.autoAdvance = elements.autoplayNextCheckbox.checked;
+        syncAutoSlideChangeForCurrentSlide();
     });
     elements.transcriptToggleBtn.addEventListener('click', async () => {
         await toggleTranscriptPanel();
@@ -385,6 +386,16 @@ function scheduleAutoAdvanceForShowtime(slide) {
     return true;
 }
 
+function syncAutoSlideChangeForCurrentSlide() {
+    const slide = state.deck?.slides[state.currentIndex];
+    if (!slide || slide.audio) {
+        clearSlideAdvanceTimer();
+        return;
+    }
+
+    scheduleAutoAdvanceForShowtime(slide);
+}
+
 async function handleSlidePlaybackCompleted() {
     if (!state.autoAdvance || !state.deck || isSlideTransitionInProgress) {
         return;
@@ -528,6 +539,7 @@ async function renderCurrentSlide() {
 
     if (!slide.audio) {
         updateSlideAudioStatus(slide);
+        syncAutoSlideChangeForCurrentSlide();
         if (isTranscriptPanelOpen()) {
             await renderTranscriptContent({keepOpen: true});
         }


### PR DESCRIPTION
### Motivation

- Ensure the slide auto-advance timer reflects the current autoplay setting immediately when the user toggles the autoplay checkbox and when a non-audio slide is rendered, fixing cases where slides would not auto-advance as expected.

### Description

- Added `syncAutoSlideChangeForCurrentSlide()` to clear or schedule the slide advance timer depending on whether the current slide has audio and the `state.autoAdvance` setting.
- Call `syncAutoSlideChangeForCurrentSlide()` from the autoplay checkbox `change` handler to apply the new setting immediately.
- Call `syncAutoSlideChangeForCurrentSlide()` from `renderCurrentSlide()` when the rendered slide has no audio so non-audio slides start their showtime countdown.
- Preserve existing behavior by clearing timers when a slide with audio is active and by delegating scheduling to `scheduleAutoAdvanceForShowtime()` for non-audio slides.

### Testing

- Ran the existing unit test suite with `npm test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb5ff678832aa713f841468668c1)