### PR TITLE
Add play-button active state and sync auto-advance/showtime for non-audio slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                 <path d="M15.5 7l-7 5 7 5V7z" />
               </svg>
             </button>
-            <button id="play-btn" class="icon-btn icon-btn--play" type="button" title="Abspielen" aria-label="Abspielen">
+            <button id="play-btn" class="icon-btn icon-btn--play" type="button" title="Abspielen" aria-label="Abspielen" aria-pressed="false">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="12" cy="12" r="9" />
                 <path d="M10 8.75l5.5 3.25L10 15.25v-6.5z" />

--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ const state = createInitialState();
 let slideAdvanceTimer = null;
 let showtimeCountdownInterval = null;
 let slideChangeCueAudioContext = null;
+let nonAudioPlaybackRemainingSeconds = null;
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const DEFAULT_SLIDE_SHOWTIME_SECONDS = 10;
 const DOUBLE_TAP_MAX_INTERVAL_MS = 320;
@@ -137,14 +138,21 @@ function bindEvents() {
     });
     elements.pauseBtn.addEventListener('click', async () => {
         clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
+        nonAudioPlaybackRemainingSeconds = null;
+        setPlayButtonActive(false);
         await audioController.pause();
     });
     elements.stopBtn.addEventListener('click', async () => {
         clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
+        nonAudioPlaybackRemainingSeconds = null;
+        setPlayButtonActive(false);
         await audioController.stop();
     });
     elements.autoplayNextCheckbox.addEventListener('change', () => {
         state.autoAdvance = elements.autoplayNextCheckbox.checked;
+        syncAutoSlideChangeForCurrentSlide();
     });
     elements.transcriptToggleBtn.addEventListener('click', async () => {
         await toggleTranscriptPanel();
@@ -271,6 +279,11 @@ function clearShowtimeCountdown() {
     }
 }
 
+function setPlayButtonActive(active) {
+    elements.playBtn?.classList.toggle('is-active', active);
+    elements.playBtn?.setAttribute('aria-pressed', active ? 'true' : 'false');
+}
+
 function resetTapState() {
     tapState.lastTapTimestamp = 0;
     tapState.lastTapX = 0;
@@ -344,13 +357,17 @@ function startShowtimeCountdown(slide) {
         return;
     }
 
-    let remainingSeconds = getSlideShowtimeSeconds(slide);
-    renderShowtimeCountdown(remainingSeconds);
+    nonAudioPlaybackRemainingSeconds = getSlideShowtimeSeconds(slide);
+    renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
     showtimeCountdownInterval = window.setInterval(() => {
-        remainingSeconds -= 1;
-        renderShowtimeCountdown(remainingSeconds);
-        if (remainingSeconds <= 0) {
+        if (nonAudioPlaybackRemainingSeconds === null) {
+            return;
+        }
+        nonAudioPlaybackRemainingSeconds = Math.max(0, nonAudioPlaybackRemainingSeconds - 1);
+        renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
+        if (nonAudioPlaybackRemainingSeconds <= 0) {
             clearShowtimeCountdown();
+            setPlayButtonActive(false);
         }
     }, 1000);
 }
@@ -385,7 +402,29 @@ function scheduleAutoAdvanceForShowtime(slide) {
     return true;
 }
 
+function syncAutoSlideChangeForCurrentSlide() {
+    const slide = state.deck?.slides[state.currentIndex];
+    if (!slide || slide.audio) {
+        nonAudioPlaybackRemainingSeconds = null;
+        clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
+        setPlayButtonActive(false);
+        return;
+    }
+
+    if (!state.autoAdvance) {
+        clearSlideAdvanceTimer();
+        setPlayButtonActive(false);
+        return;
+    }
+
+    setPlayButtonActive(true);
+    startShowtimeCountdown(slide);
+    scheduleAutoAdvanceForShowtime(slide);
+}
+
 async function handleSlidePlaybackCompleted() {
+    setPlayButtonActive(false);
     if (!state.autoAdvance || !state.deck || isSlideTransitionInProgress) {
         return;
     }
@@ -497,6 +536,8 @@ function delay(durationMs) {
 async function renderCurrentSlide() {
     clearSlideAdvanceTimer();
     clearShowtimeCountdown();
+    nonAudioPlaybackRemainingSeconds = null;
+    setPlayButtonActive(false);
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
         elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
@@ -524,14 +565,19 @@ async function renderCurrentSlide() {
   `;
 
     await hydrateAsyncAssets();
-    startShowtimeCountdown(slide);
 
     if (!slide.audio) {
         updateSlideAudioStatus(slide);
+        syncAutoSlideChangeForCurrentSlide();
         if (isTranscriptPanelOpen()) {
             await renderTranscriptContent({keepOpen: true});
         }
         return;
+    }
+
+    if (elements.showtimeCountdown) {
+        elements.showtimeCountdown.textContent = '–';
+        elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
     }
 
     if (isTranscriptPanelOpen()) {
@@ -560,10 +606,19 @@ async function playCurrentSlide(options = {}) {
     }
     await withErrorHandling(async () => {
         if (!slide.audio) {
-            scheduleAutoAdvanceForShowtime(slide);
+            setPlayButtonActive(true);
+            startShowtimeCountdown(slide);
+            if (state.autoAdvance) {
+                scheduleAutoAdvanceForShowtime(slide);
+            } else {
+                clearSlideAdvanceTimer();
+            }
             return;
         }
         clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
+        nonAudioPlaybackRemainingSeconds = null;
+        setPlayButtonActive(true);
         await audioController.play(slide, state.deck.assetLoader);
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -146,6 +146,11 @@ button:disabled {
     background: linear-gradient(180deg, rgba(53, 94, 127, 0.96), rgba(28, 58, 84, 0.98));
 }
 
+.icon-btn--play.is-active {
+    background: linear-gradient(180deg, rgba(77, 138, 187, 0.98), rgba(33, 73, 104, 0.98));
+    box-shadow: 0 0 0 2px rgba(108, 192, 255, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
 .icon-btn .icon {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
### Motivation
- Make it visually and programmatically clear when the play control is active for non-audio slides and ensure showtime auto-advance and countdown remain synchronized with the UI state.
- Avoid inconsistent countdown/state after pause/stop or when toggling the "Autoplay next" checkbox on slides without audio.

### Description
- Add `aria-pressed="false"` to the play button in `index.html` and introduce the `setPlayButtonActive` helper to toggle the `.is-active` class and `aria-pressed` state.
- Track non-audio playback with a new `nonAudioPlaybackRemainingSeconds` variable and centralize countdown behavior in `startShowtimeCountdown`, `clearShowtimeCountdown`, and `renderShowtimeCountdown`.
- Add `syncAutoSlideChangeForCurrentSlide` to reconcile `state.autoAdvance`, countdown, and timers for the current slide, and call it when `autoplayNextCheckbox` changes and when rendering non-audio slides.
- Update handlers in `playCurrentSlide`, `renderCurrentSlide`, `pause`/`stop` actions and slide-completion logic to correctly clear timers, update the play button state, and manage showtime countdowns.
- Add CSS for `.icon-btn--play.is-active` in `src/styles.css` to provide a distinct visual state for the active play button.

### Testing
- Ran `npm test` and all automated unit tests passed.
- Ran `npm run lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb5ff678832aa713f841468668c1)