### PR TITLE
Fix unintended toolbar interactions for play and transcript controls

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -122,19 +122,22 @@ function bindEvents() {
     elements.nextBtn.addEventListener('click', () => goToSlide(state.currentIndex + 1));
     elements.lastBtn.addEventListener('click', () => goToSlide(state.deck?.slides.length - 1 ?? -1));
     elements.gotoBtn.addEventListener('click', () => goToSlide(Number(elements.gotoInput.value) - 1));
-    elements.playBtn.addEventListener('click', async () => {
+    elements.playBtn.addEventListener('click', async (event) => {
+        event.preventDefault();
         if (!state.deck || state.currentIndex < 0) {
             return;
         }
 
         if (elements.audioStatus.textContent === 'Pausiert') {
             await audioController.resume();
+            keepPlaybackButtonFocus();
             return;
         }
 
         await withErrorHandling(async () => {
             await playCurrentSlide();
         });
+        keepPlaybackButtonFocus();
     });
     elements.pauseBtn.addEventListener('click', async () => {
         clearSlideAdvanceTimer();
@@ -154,8 +157,15 @@ function bindEvents() {
         state.autoAdvance = elements.autoplayNextCheckbox.checked;
         syncAutoSlideChangeForCurrentSlide();
     });
-    elements.transcriptToggleBtn.addEventListener('click', async () => {
+    elements.transcriptToggleBtn.addEventListener('click', async (event) => {
+        event.preventDefault();
+        const previousAutoAdvance = state.autoAdvance;
         await toggleTranscriptPanel();
+        if (state.autoAdvance !== previousAutoAdvance) {
+            state.autoAdvance = previousAutoAdvance;
+            elements.autoplayNextCheckbox.checked = previousAutoAdvance;
+            syncAutoSlideChangeForCurrentSlide();
+        }
     });
 
     document.addEventListener('keydown', async (event) => {
@@ -184,6 +194,12 @@ function bindEvents() {
         resetSwipeState(swipeState);
         resetTapState();
     }, {passive: true});
+}
+
+function keepPlaybackButtonFocus() {
+    if (document.activeElement === elements.gotoInput) {
+        elements.playBtn.focus({preventScroll: true});
+    }
 }
 
 function handleTouchStart(event) {


### PR DESCRIPTION
### Motivation
- Klicks auf die Toolbar-Buttons hatten unerwünschte Nebeneffekte: Ein Klick auf `#play-btn` konnte den Fokus in das `#goto-input` verschieben und ein Klick auf das `#transcript-toggle-btn` konnte den Zustand der Autoplay-Checkbox verändern.
- Ziel ist, diese Seiteneffekte zu vermeiden, sodass Wiedergabe- und Transkript-Toggle-Klicks nur ihre beabsichtigte Aktion auslösen.

### Description
- Verhindert die Standard-Click-Interaktion für den Play-Button durch Hinzufügen von `event.preventDefault()` im `click`-Handler von `#play-btn` und stellt mit `keepPlaybackButtonFocus()` sicher, dass der Fokus bei Bedarf wieder auf `#play-btn` gesetzt wird.
- Verhindert die Standard-Click-Interaktion für das Transkript-Augen-Icon durch Hinzufügen von `event.preventDefault()` im `click`-Handler von `#transcript-toggle-btn`.
- Bewahrt und stellt beim Umschalten des Transkript-Panels den vorherigen Wert von `state.autoAdvance` wieder her und synchronisiert anschließend mit `syncAutoSlideChangeForCurrentSlide()` damit die `#autoplay-next-checkbox` durch das Öffnen/Schließen des Panels nicht verändert wird.

### Testing
- `node --check src/app.js` ausgeführt und erfolgreich (Syntax-Check bestanden).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd5d9867c832a86c58ec3cc392337)