### PR TITLE
Fallback-Countdown und Audio-Fehlermeldungen für nicht verfügbare Folien-Audios

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,6 +80,16 @@ const audioController = new AudioController({
     async onEnded() {
         await handleSlidePlaybackCompleted();
     },
+    onFallbackTimerStart(seconds) {
+        if (!state.autoAdvance) {
+            return;
+        }
+        setPlayButtonActive(true);
+        startShowtimeCountdown(null, {seconds});
+    },
+    onAudioIssue(message) {
+        showError(`⚠️ ${message}`);
+    },
 });
 
 bindEvents();
@@ -363,9 +373,12 @@ function renderShowtimeCountdown(value) {
     elements.showtimeCountdown.classList.toggle('is-danger', safeValue <= 3);
 }
 
-function startShowtimeCountdown(slide) {
+function startShowtimeCountdown(slide, options = {}) {
     clearShowtimeCountdown();
-    if (!slide) {
+    const overrideSeconds = Number(options.seconds);
+    const hasOverride = Number.isFinite(overrideSeconds) && overrideSeconds > 0;
+
+    if (!slide && !hasOverride) {
         if (elements.showtimeCountdown) {
             elements.showtimeCountdown.textContent = '–';
             elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
@@ -373,7 +386,7 @@ function startShowtimeCountdown(slide) {
         return;
     }
 
-    nonAudioPlaybackRemainingSeconds = getSlideShowtimeSeconds(slide);
+    nonAudioPlaybackRemainingSeconds = hasOverride ? overrideSeconds : getSlideShowtimeSeconds(slide);
     renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
     showtimeCountdownInterval = window.setInterval(() => {
         if (nonAudioPlaybackRemainingSeconds === null) {
@@ -811,6 +824,7 @@ function checkAudioSupport() {
         showError(`
         ⚠️ Sprachwiedergabe wird von diesem Browser nicht unterstützt.
         👉 Bitte nutze ein Gerät mit funktionierender SpeechSynthesis, häufig funzt ein Chrome Browser.
+        ℹ️ Falls eine Folie Audio per TTS benötigt, wird stattdessen eine Fallback-Showtime von 10 Sekunden verwendet.
         `);
     }
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,7 +1,9 @@
 export class AudioController {
-    constructor({onStatusChange, onEnded}) {
+    constructor({onStatusChange, onEnded, onFallbackTimerStart, onAudioIssue}) {
         this.onStatusChange = onStatusChange;
         this.onEnded = onEnded;
+        this.onFallbackTimerStart = onFallbackTimerStart;
+        this.onAudioIssue = onAudioIssue;
         this.audio = null;
         this.synthesis = typeof window !== 'undefined' ? window.speechSynthesis : undefined;
         this.currentMode = 'stopped';
@@ -58,11 +60,13 @@ export class AudioController {
                 return;
             }
 
-            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds(slide)} s`);
+            this.reportAudioIssue('Audioformat wird nicht unterstützt. Es wird eine Fallback-Showtime von 10 Sekunden verwendet.');
+            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds()} s`);
             this.scheduleFallbackAdvance(slide, playbackSession);
         } catch (error) {
             console.warn('Audio konnte nicht geladen werden. Fallback-Showtime wird verwendet.', error);
-            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds(slide)} s`);
+            this.reportAudioIssue('Audio konnte nicht geladen werden. Es wird eine Fallback-Showtime von 10 Sekunden verwendet.');
+            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds()} s`);
             this.scheduleFallbackAdvance(slide, playbackSession);
         }
     }
@@ -128,7 +132,8 @@ export class AudioController {
             }
             console.warn('Audio-Datei konnte nicht abgespielt werden. Fallback-Showtime wird verwendet.', url);
             this.audio = null;
-            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds(slide)} s`);
+            this.reportAudioIssue('Audio-Datei konnte nicht abgespielt werden. Es wird eine Fallback-Showtime von 10 Sekunden verwendet.');
+            this.updateStatus(`Audio nicht verfügbar – Anzeige ${getUnavailableAudioShowtimeSeconds()} s`);
             this.scheduleFallbackAdvance(slide, playbackSession);
         }, {once: true});
         audio.addEventListener('pause', () => {
@@ -150,6 +155,7 @@ export class AudioController {
 
     playSpeech(text, audioConfig = {}, isSsml, playbackSession, slide = {}) {
         if (!this.isSpeechReallyUsable()) {
+            this.reportAudioIssue('Sprachausgabe wird von diesem Browser nicht unterstützt. Es wird eine Fallback-Showtime von 10 Sekunden verwendet.');
             this.updateStatus('Sprachausgabe nicht unterstützt');
             this.scheduleFallbackAdvance(slide, playbackSession);
             return;
@@ -188,8 +194,9 @@ export class AudioController {
             if (!this.isCurrentPlaybackSession(playbackSession)) {
                 return;
             }
+            this.reportAudioIssue(`Fehler bei der Sprachausgabe (${event.error || 'unbekannt'}). Es wird eine Fallback-Showtime von 10 Sekunden verwendet.`);
             this.updateStatus(`TTS-Fehler: ${event.error || 'unbekannt'}`);
-            this.onEnded?.();
+            this.scheduleFallbackAdvance(slide, playbackSession);
         };
 
         this.synthesis.speak(utterance);
@@ -198,6 +205,7 @@ export class AudioController {
     scheduleFallbackAdvance(slide = {}, playbackSession) {
         this.clearUnavailableAudioFallbackTimer();
         const fallbackSeconds = getUnavailableAudioShowtimeSeconds(slide);
+        this.onFallbackTimerStart?.(fallbackSeconds);
         this.unavailableAudioFallbackTimer = window.setTimeout(() => {
             this.unavailableAudioFallbackTimer = null;
             if (!this.isCurrentPlaybackSession(playbackSession)) {
@@ -222,6 +230,10 @@ export class AudioController {
 
     isCurrentPlaybackSession(playbackSession) {
         return playbackSession === this.playbackSession;
+    }
+
+    reportAudioIssue(message) {
+        this.onAudioIssue?.(message);
     }
 }
 
@@ -248,11 +260,7 @@ function inferAudioType(audioConfig = {}) {
 
 const DEFAULT_UNAVAILABLE_AUDIO_SHOWTIME_SECONDS = 10;
 
-function getUnavailableAudioShowtimeSeconds(slide = {}) {
-    const showtime = Number(slide.showtime);
-    if (Number.isFinite(showtime) && showtime > 0) {
-        return showtime;
-    }
+function getUnavailableAudioShowtimeSeconds() {
     return DEFAULT_UNAVAILABLE_AUDIO_SHOWTIME_SECONDS;
 }
 


### PR DESCRIPTION
### Motivation

- Beim Klick auf den Play-Button mit aktivierter automatischer Folienwechsel-Checkbox soll die Autoplay-Logik auch dann sichtbar einen Countdown starten und die Folie nach einer sinnvollen Fallback-Zeit weiterblättern, wenn Audio/TTS nicht verfügbar ist oder ein Wiedergabefehler auftritt.
- Fehlende oder fehlerhafte Audiowiedergabe soll dem Anwender klar als Fehlernachricht angezeigt werden und eine konstante Fallback-Showtime verwendet werden (10 s).

### Description

- Die `AudioController`-API wurde erweitert um zwei Callback-Optionen `onFallbackTimerStart` und `onAudioIssue`, die der App melden, wenn ein Fallback-Timer startet bzw. ein Audio-Problem auftritt. (`AudioController`)
- Fehlerpunkte bei nicht unterstütztem Format, Ladefehler, Playback-Fehler und TTS-Fehler rufen jetzt `onAudioIssue` und einen Fallback-Pfad auf; die Fallback-Showtime ist fest auf 10 s (`getUnavailableAudioShowtimeSeconds` vereinfacht). (`src/audio.js`)
- Die App verbindet die neuen Callbacks so, dass bei Fallback ein sichtbarer Countdown gestartet wird (`startShowtimeCountdown` wurde erweitert, um eine Sekunden-Override-Option zu akzeptieren) und Fehlernachrichten mit `showError` angezeigt werden. (`src/app.js`)
- Die Browser-Hinweismeldung für fehlende SpeechSynthesis wurde ergänzt, dass in diesem Fall eine 10‑Sekunden-Fallback-Showtime verwendet wird. (`src/app.js`)

### Testing

- Syntax/Quick-Checks wurden ausgeführt mit `node --check src/app.js` und `node --check src/audio.js`, beide Prüfungen sind erfolgreich gelaufen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfda19e2e4832a8f474800243b2d2f)