### PR TITLE
Disable transcript toggle when no slide audio is configured

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -679,6 +679,7 @@ function renderSlideList() {
 
 function refreshUi() {
     const slideCount = state.deck?.slides.length ?? 0;
+    const currentSlide = state.deck?.slides[state.currentIndex];
     elements.deckTitle.textContent = state.deck?.title ?? '–';
     elements.sourceKind.textContent = state.sourceKind ?? '–';
     elements.slideCounter.textContent = slideCount > 0 ? `${state.currentIndex + 1} / ${slideCount}` : '0 / 0';
@@ -701,7 +702,12 @@ function refreshUi() {
     }
 
     elements.gotoInput.disabled = disabled;
-    elements.transcriptToggleBtn.disabled = disabled;
+    elements.transcriptToggleBtn.disabled = disabled || !hasSlideAudioSource(currentSlide);
+}
+
+function hasSlideAudioSource(slide) {
+    const source = slide?.audio?.src;
+    return typeof source === 'string' && source.trim().length > 0;
 }
 
 async function toggleTranscriptPanel() {


### PR DESCRIPTION
### Motivation
- Prevent the transcript/eye toggle from being enabled for slides that have no configured audio source so the panel cannot be opened for empty/irrelevant content.

### Description
- Add a small helper `hasSlideAudioSource(slide)` and update `refreshUi()` to disable `elements.transcriptToggleBtn` when there is no slide audio by using `disabled || !hasSlideAudioSource(currentSlide)`.

### Testing
- Ran `node --check src/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe36e54b0832aa2a4e96982ad029a)