### PR TITLE
Support remote .sld bundles in deck loader (#41)

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -53,13 +53,14 @@ export async function loadDeckFromZip(file) {
 export async function loadDeckFromRemote(url) {
   const normalizedUrl = new URL(url, window.location.href).href;
 
-  if (normalizedUrl.toLowerCase().endsWith('.zip')) {
+  if (isArchiveBundleUrl(normalizedUrl)) {
     const response = await fetch(normalizedUrl);
     if (!response.ok) {
-      throw new Error(`Remote-ZIP konnte nicht geladen werden: HTTP ${response.status}`);
+      throw new Error(`Remote-SLD/ZIP konnte nicht geladen werden: HTTP ${response.status}`);
     }
     const blob = await response.blob();
-    return loadDeckFromZip(new File([blob], 'remote.zip', { type: 'application/zip' }));
+    const remoteFileName = inferRemoteFileName(normalizedUrl);
+    return loadDeckFromZip(new File([blob], remoteFileName, { type: 'application/zip' }));
   }
 
   const manifestUrl = normalizedUrl.toLowerCase().endsWith('slides.json')
@@ -182,6 +183,20 @@ function createObjectUrlFromHandle(rootHandle, relativePath) {
 
 function ensureDirectoryUrl(url) {
   return url.endsWith('/') ? url : `${url}/`;
+}
+
+function inferRemoteFileName(url) {
+  const pathname = new URL(url).pathname;
+  const candidate = pathname.split('/').pop();
+  if (!candidate) {
+    return 'remote.sld';
+  }
+  return candidate;
+}
+
+function isArchiveBundleUrl(url) {
+  const pathname = new URL(url).pathname.toLowerCase();
+  return pathname.endsWith('.zip') || pathname.endsWith('.sld');
 }
 
 function normalize(path) {


### PR DESCRIPTION
### Motivation
- Remote-URLs mit der Endung `.sld` sollten wie ZIP-/SLD-Bundles behandelt werden, damit Slideshows direkt als `.sld`-Archiv geladen werden können.
- Beim Erzeugen des in-memory `File`-Objekts für `JSZip` sollte der entfernte Dateiname erhalten bleiben, statt starr `remote.zip` zu verwenden.

### Description
- `loadDeckFromRemote` erkennt jetzt Archive sowohl mit `.sld` als auch `.zip` über die neue Helferfunktion `isArchiveBundleUrl` und behandelt beide gleich.  
- Beim Laden eines entfernten Archivs wird der Dateiname aus der URL über `inferRemoteFileName` ermittelt und beim Erstellen des `File`-Objekts an `loadDeckFromZip` weitergereicht.  
- Die Fehlermeldung beim Fehlschlag des Archiv-Fetches nennt jetzt korrekt `Remote-SLD/ZIP` statt nur `Remote-ZIP`.  
- Neue Hilfsfunktionen `inferRemoteFileName` und `isArchiveBundleUrl` wurden in `src/loaders.js` hinzugefügt.

### Testing
- `node --check src/loaders.js` wurde ausgeführt und zeigte keine Syntaxfehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe679aa88832ab48de3377383b7b6)