### PR TITLE
Show slide-change cue indicator and centralize countdown rendering

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ let slideAdvanceTimer = null;
 let showtimeCountdownInterval = null;
 let slideChangeCueAudioContext = null;
 let nonAudioPlaybackRemainingSeconds = null;
+let slideChangeCueIndicatorToken = 0;
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const DEFAULT_SLIDE_SHOWTIME_SECONDS = 10;
 const DOUBLE_TAP_MAX_INTERVAL_MS = 320;
@@ -373,16 +374,42 @@ function renderShowtimeCountdown(value) {
     elements.showtimeCountdown.classList.toggle('is-danger', safeValue <= 3);
 }
 
+function renderShowtimeDash() {
+    if (!elements.showtimeCountdown) {
+        return;
+    }
+    elements.showtimeCountdown.textContent = '–';
+    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+}
+
+function showSlideChangeCueIndicator() {
+    if (!elements.showtimeCountdown) {
+        return 0;
+    }
+    slideChangeCueIndicatorToken += 1;
+    elements.showtimeCountdown.textContent = '🔔';
+    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+    return slideChangeCueIndicatorToken;
+}
+
+function restoreShowtimeCountdownAfterCue(token) {
+    if (!elements.showtimeCountdown || token !== slideChangeCueIndicatorToken) {
+        return;
+    }
+    if (nonAudioPlaybackRemainingSeconds !== null) {
+        renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
+        return;
+    }
+    renderShowtimeDash();
+}
+
 function startShowtimeCountdown(slide, options = {}) {
     clearShowtimeCountdown();
     const overrideSeconds = Number(options.seconds);
     const hasOverride = Number.isFinite(overrideSeconds) && overrideSeconds > 0;
 
     if (!slide && !hasOverride) {
-        if (elements.showtimeCountdown) {
-            elements.showtimeCountdown.textContent = '–';
-            elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
-        }
+        renderShowtimeDash();
         return;
     }
 
@@ -463,7 +490,7 @@ async function handleSlidePlaybackCompleted() {
         return;
     }
 
-    playSlideChangeCue();
+    playSlideChangeCueWithIndicator();
 }
 
 async function initializeFromQueryParameters() {
@@ -513,7 +540,7 @@ async function goToSlide(index, options = {}) {
         resetTapState();
         await audioController.stop();
         if (options.autoplay) {
-            const bellDurationSeconds = playSlideChangeCue();
+            const bellDurationSeconds = playSlideChangeCueWithIndicator();
             await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
         }
         state.currentIndex = index;
@@ -556,6 +583,20 @@ function playSlideChangeCue() {
     }
 }
 
+function playSlideChangeCueWithIndicator() {
+    const bellDurationSeconds = playSlideChangeCue();
+    if (bellDurationSeconds <= 0) {
+        return bellDurationSeconds;
+    }
+
+    const indicatorToken = showSlideChangeCueIndicator();
+    window.setTimeout(() => {
+        restoreShowtimeCountdownAfterCue(indicatorToken);
+    }, bellDurationSeconds * 1000);
+
+    return bellDurationSeconds;
+}
+
 function delay(durationMs) {
     return new Promise((resolve) => {
         window.setTimeout(resolve, durationMs);
@@ -571,8 +612,7 @@ async function renderCurrentSlide() {
     if (!slide) {
         elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
         if (elements.showtimeCountdown) {
-            elements.showtimeCountdown.textContent = '–';
-            elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+            renderShowtimeDash();
         }
         hideTranscriptPanel();
         return;
@@ -605,8 +645,7 @@ async function renderCurrentSlide() {
     }
 
     if (elements.showtimeCountdown) {
-        elements.showtimeCountdown.textContent = '–';
-        elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+        renderShowtimeDash();
     }
 
     if (isTranscriptPanelOpen()) {


### PR DESCRIPTION
### Motivation

- Provide a visible indicator in the showtime countdown when the slide-change bell plays so users see a cue even if audio is unavailable or muted.
- Reduce duplicated code by centralizing rendering of the showtime dash display.
- Avoid race conditions when the cue indicator is shown and multiple bell playbacks overlap.

### Description

- Added `slideChangeCueIndicatorToken` and token-based functions `showSlideChangeCueIndicator` and `restoreShowtimeCountdownAfterCue` to display a bell emoji in the countdown and safely restore the prior countdown state only for the latest cue.
- Added `renderShowtimeDash` to centralize the logic that renders the `–` dash into the showtime countdown element and replaced several inline manipulations with calls to this function.
- Introduced `playSlideChangeCueWithIndicator` which wraps the existing `playSlideChangeCue` and shows the cue indicator for the duration of the bell before restoring the countdown, and replaced direct calls to `playSlideChangeCue` in autoplay flows with this wrapper.
- Kept existing audio playback logic and added a token-based timeout to prevent stale/restoration races when multiple cues are triggered rapidly.

### Testing

- Ran the existing unit test suite with `npm test` and all tests passed.
- Ran linting via `npm run lint` with no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe9e7eeec832aa1c38fbd5862848d)