### PR TITLE
Sprech-Icon im Showtime-Feld während Audiowiedergabe anzeigen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -77,6 +77,11 @@ const elements = {
 const audioController = new AudioController({
     onStatusChange(status) {
         elements.audioStatus.textContent = status;
+        if (status.startsWith('Spielt')) {
+            renderSpeakingIndicator();
+        } else if (!showtimeCountdownInterval) {
+            renderShowtimeDash();
+        }
     },
     async onEnded() {
         await handleSlidePlaybackCompleted();
@@ -370,6 +375,7 @@ function renderShowtimeCountdown(value) {
 
     const safeValue = Math.max(0, Math.floor(value));
     elements.showtimeCountdown.textContent = String(safeValue);
+    elements.showtimeCountdown.classList.remove('is-speaking');
     elements.showtimeCountdown.classList.toggle('is-safe', safeValue > 3);
     elements.showtimeCountdown.classList.toggle('is-danger', safeValue <= 3);
 }
@@ -379,7 +385,16 @@ function renderShowtimeDash() {
         return;
     }
     elements.showtimeCountdown.textContent = '–';
+    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking');
+}
+
+function renderSpeakingIndicator() {
+    if (!elements.showtimeCountdown) {
+        return;
+    }
+    elements.showtimeCountdown.textContent = '🗣️';
     elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+    elements.showtimeCountdown.classList.add('is-speaking');
 }
 
 function showSlideChangeCueIndicator() {
@@ -388,7 +403,7 @@ function showSlideChangeCueIndicator() {
     }
     slideChangeCueIndicatorToken += 1;
     elements.showtimeCountdown.textContent = '🔔';
-    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
+    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking');
     return slideChangeCueIndicatorToken;
 }
 
@@ -644,9 +659,7 @@ async function renderCurrentSlide() {
         return;
     }
 
-    if (elements.showtimeCountdown) {
-        renderShowtimeDash();
-    }
+    renderShowtimeDash();
 
     if (isTranscriptPanelOpen()) {
         await renderTranscriptContent({keepOpen: true});
@@ -687,6 +700,7 @@ async function playCurrentSlide(options = {}) {
         clearShowtimeCountdown();
         nonAudioPlaybackRemainingSeconds = null;
         setPlayButtonActive(true);
+        renderSpeakingIndicator();
         await audioController.play(slide, state.deck.assetLoader);
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -198,6 +198,10 @@ button:disabled {
     color: #ff7b72;
 }
 
+.showtime-countdown.is-speaking {
+    color: #6cc0ff;
+}
+
 input[type="url"],
 input[type="number"] {
     padding: 10px 12px;


### PR DESCRIPTION
### Motivation
- Die UI soll während aktiver Audiowiedergabe klarer signalisieren, dass gerade gesprochen/gespielt wird, statt einen Countdown oder einen Strich anzuzeigen.
- Die Anzeige muss zuverlässig zwischen Zuständen (Countdown, Glocke, Sprechmodus) wechseln, ohne dass ein vorheriger Indikator "hängen bleibt".

### Description
- Fügt in `src/app.js` die Funktion `renderSpeakingIndicator()` hinzu, die das Showtime-Feld auf `🗣️` setzt und die CSS-Klasse `is-speaking` hinzufügt, sowie an den passenden Stellen `is-speaking` entfernt (Countdown, Dash, Slide-change-Cue).
- Aktualisiert die `onStatusChange`-Callback-Logik des `AudioController`, sodass bei Statusen, die mit `Spielt` beginnen, sofort `renderSpeakingIndicator()` gerufen wird und andernfalls bei nicht laufendem Countdown `renderShowtimeDash()` wiederhergestellt wird.
- Setzt das Sprech-Icon auch unmittelbar beim Start der Audiowiedergabe in `playCurrentSlide()` für sofortiges visuelles Feedback und stellt sicher, dass Fallback-/Fehlerpfade weiterhin den Countdown anzeigen.
- Ergänzt `src/styles.css` um `.showtime-countdown.is-speaking` zur visuellen Abgrenzung des Sprech-Icons.

### Testing
- Syntax-Checks wurden ausgeführt mit `node --check src/app.js` und `node --check src/audio.js`, beide Befehle liefen ohne Fehler (erfolgreich).
- Es wurden keine browserbasierten Integrationstests in dieser Umgebung ausgeführt, daher visuelle Verifikation ist in einem Browser empfehlenswert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfee851150832a9ac6e6087f119ab1)