### PR TITLE
Use `helleGlocke` from `glocke.js` for slide-change cue

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,8 +6,8 @@ import {
     SLIDE_CHANGE_BELL_DECAY_SECONDS,
     SLIDE_CHANGE_BELL_STRIKE_SECONDS,
     SLIDE_CHANGE_BELL_VOLUME,
-    playSlideChangeGong,
 } from './gong.js';
+import {helleGlocke} from './glocke.js';
 import {
     canPlayInAudioElement,
     inferAudioType,
@@ -587,7 +587,7 @@ function playSlideChangeCue() {
             });
         }
 
-        return playSlideChangeGong(context, {
+        return helleGlocke(context, {
             volume: SLIDE_CHANGE_BELL_VOLUME,
             strikeSeconds: SLIDE_CHANGE_BELL_STRIKE_SECONDS,
             decaySeconds: SLIDE_CHANGE_BELL_DECAY_SECONDS,


### PR DESCRIPTION
### Motivation
- Replace the previous `playSlideChangeGong` implementation with the new `helleGlocke` function to update how the slide-change cue is produced.

### Description
- Remove the `playSlideChangeGong` import from `gong.js` and add an import of `helleGlocke` from `glocke.js` in `src/app.js`.
- Call `helleGlocke(context, {...})` inside `playSlideChangeCue` using the existing `SLIDE_CHANGE_BELL_*` parameters to preserve the cue behavior.

### Testing
- Ran the project's automated test suite with `npm test` and linting with `npm run lint`; existing tests and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff4fd9088832aa686dbd8960f5fa2)