### PR TITLE
Use new bell synthesizer with gong fallback and robust manifest loading

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,8 +6,9 @@ import {
     SLIDE_CHANGE_BELL_DECAY_SECONDS,
     SLIDE_CHANGE_BELL_STRIKE_SECONDS,
     SLIDE_CHANGE_BELL_VOLUME,
+    playSlideChangeGong,
 } from './gong.js';
-import {helleGlocke} from './glocke.js';
+import {helleGlocke, playGlockeTone} from './glocke.js';
 import {
     canPlayInAudioElement,
     inferAudioType,
@@ -587,11 +588,20 @@ function playSlideChangeCue() {
             });
         }
 
-        return helleGlocke(context, {
-            volume: SLIDE_CHANGE_BELL_VOLUME,
-            strikeSeconds: SLIDE_CHANGE_BELL_STRIKE_SECONDS,
-            decaySeconds: SLIDE_CHANGE_BELL_DECAY_SECONDS,
-        });
+        try {
+            return playGlockeTone(context, helleGlocke, {
+                loudness: Math.min(1, Math.max(0.0001, SLIDE_CHANGE_BELL_VOLUME / 4)),
+                attack: SLIDE_CHANGE_BELL_STRIKE_SECONDS,
+                duration: SLIDE_CHANGE_BELL_DECAY_SECONDS,
+            });
+        } catch (glockeError) {
+            console.debug('helleGlocke fehlgeschlagen, nutze Gong-Fallback.', glockeError);
+            return playSlideChangeGong(context, {
+                volume: SLIDE_CHANGE_BELL_VOLUME,
+                strikeSeconds: SLIDE_CHANGE_BELL_STRIKE_SECONDS,
+                decaySeconds: SLIDE_CHANGE_BELL_DECAY_SECONDS,
+            });
+        }
     } catch (error) {
         console.debug('Slide-Change-Cue konnte nicht abgespielt werden.', error);
         return 0;

--- a/src/glocke.js
+++ b/src/glocke.js
@@ -23,7 +23,7 @@
  *   detune: 6
  * });
  */
-const HELLE_GLOCKE = {
+export const helleGlocke = {
   pitchHz: 520,
   loudness: 0.8,
   duration: 3.5,
@@ -34,7 +34,7 @@ const HELLE_GLOCKE = {
   detune: 12
 };
 
-const GROSSE_GLOCKE = {
+export const grosseGlocke = {
   pitchHz: 220,
   loudness: 0.9,
   duration: 6,
@@ -45,7 +45,7 @@ const GROSSE_GLOCKE = {
   detune: 5
 };
 
-const KLEINE_HELLE_GLOCKE = {
+export const kleineGlocke = {
   pitchHz: 880,
   loudness: 0.5,
   duration: 2.5,
@@ -218,6 +218,91 @@ async function playBellTone(options = {}) {
   });
 }
 
-const helleGlocke = () => playBellTone(HELLE_GLOCKE);
-const grosseGlocke = () => playBellTone(GROSSE_GLOCKE);
-const kleineGlocke = () => playBellTone(KLEINE_HELLE_GLOCKE);
+export function playGlockeTone(context, preset = helleGlocke, overrides = {}) {
+  const merged = { ...preset, ...overrides };
+  const pitchHz = clamp(merged.pitchHz ?? 440, 50, 4000);
+  const loudness = clamp(merged.loudness ?? 0.7, 0.0001, 1);
+  const duration = clamp(merged.duration ?? 4, 0.1, 20);
+  const fullness = clamp(merged.fullness ?? 0.7, 0, 1);
+  const brightness = clamp(merged.brightness ?? 0.5, 0, 1);
+  const attack = clamp(merged.attack ?? 0.01, 0.001, 0.15);
+  const overtones = clamp(merged.overtones ?? 0.7, 0, 1);
+  const detune = clamp(merged.detune ?? 4, 0, 50);
+
+  const now = context.currentTime;
+  const endTime = now + duration + 0.5;
+
+  const masterGain = context.createGain();
+  const lowpass = context.createBiquadFilter();
+  const highpass = context.createBiquadFilter();
+
+  highpass.type = "highpass";
+  highpass.frequency.value = 80;
+  lowpass.type = "lowpass";
+  lowpass.frequency.value = 1200 + brightness * 6000;
+  lowpass.Q.value = 0.7;
+
+  masterGain.gain.setValueAtTime(0.0001, now);
+  masterGain.gain.exponentialRampToValueAtTime(loudness, now + attack);
+  masterGain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+  lowpass.connect(highpass);
+  highpass.connect(masterGain);
+  masterGain.connect(context.destination);
+
+  const partials = [
+    { ratio: 0.50, gain: 0.18 + fullness * 0.10, decay: 1.20 },
+    { ratio: 1.00, gain: 0.30 + fullness * 0.15, decay: 1.00 },
+    { ratio: 2.00, gain: 0.22 + overtones * 0.18, decay: 0.75 },
+    { ratio: 2.40, gain: 0.10 + brightness * 0.12, decay: 0.60 },
+    { ratio: 3.00, gain: 0.08 + overtones * 0.10, decay: 0.50 },
+    { ratio: 4.20, gain: 0.05 + brightness * 0.10, decay: 0.40 },
+    { ratio: 5.40, gain: 0.03 + brightness * 0.08, decay: 0.30 }
+  ];
+
+  for (const partial of partials) {
+    const oscA = context.createOscillator();
+    const oscB = context.createOscillator();
+    const partialGain = context.createGain();
+
+    oscA.type = "sine";
+    oscB.type = brightness > 0.65 ? "triangle" : "sine";
+    const partialFrequency = pitchHz * partial.ratio;
+    oscA.frequency.setValueAtTime(partialFrequency, now);
+    oscB.frequency.setValueAtTime(partialFrequency, now);
+    oscA.detune.setValueAtTime(-detune / 2, now);
+    oscB.detune.setValueAtTime(detune / 2, now);
+
+    const startGain = Math.max(0.0001, partial.gain * loudness);
+    const partialDuration = Math.max(0.08, duration * partial.decay);
+    partialGain.gain.setValueAtTime(0.0001, now);
+    partialGain.gain.exponentialRampToValueAtTime(startGain, now + attack);
+    partialGain.gain.exponentialRampToValueAtTime(0.0001, now + partialDuration);
+
+    oscA.connect(partialGain);
+    oscB.connect(partialGain);
+    partialGain.connect(lowpass);
+    oscA.start(now);
+    oscB.start(now);
+    oscA.stop(endTime);
+    oscB.stop(endTime);
+  }
+
+  const strikeOsc = context.createOscillator();
+  const strikeGain = context.createGain();
+  const strikeFilter = context.createBiquadFilter();
+  strikeOsc.type = "triangle";
+  strikeOsc.frequency.setValueAtTime(1200 + brightness * 1800, now);
+  strikeFilter.type = "bandpass";
+  strikeFilter.frequency.value = 1800 + brightness * 2200;
+  strikeFilter.Q.value = 3;
+  strikeGain.gain.setValueAtTime(0.0001, now);
+  strikeGain.gain.exponentialRampToValueAtTime(0.15 + brightness * 0.2, now + 0.002);
+  strikeGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.05);
+  strikeOsc.connect(strikeFilter);
+  strikeFilter.connect(strikeGain);
+  strikeGain.connect(lowpass);
+  strikeOsc.start(now);
+  strikeOsc.stop(now + 0.06);
+
+  return duration;
+}

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -96,9 +96,17 @@ async function buildDeck(manifest, assetLoader) {
   validateManifest(manifest);
 
   const slides = [];
+  const loadErrors = [];
   for (const [index, slide] of manifest.slides.entries()) {
     const contentPath = slide.content;
-    const contentText = await assetLoader.loadText(contentPath);
+    let contentText;
+    try {
+      contentText = await assetLoader.loadText(contentPath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      loadErrors.push(`Folie ${index + 1}: ${contentPath} (${message})`);
+      contentText = `# Fehler beim Laden\n\nDie Folien-Datei \`${contentPath}\` konnte nicht geladen werden.`;
+    }
     slides.push({
       ...slide,
       audio: normalizeAudio(slide.audio),
@@ -108,6 +116,12 @@ async function buildDeck(manifest, assetLoader) {
       contentText,
       format: slide.format,
     });
+  }
+
+  if (loadErrors.length > 0) {
+    console.warn(
+      `Einige Folieninhalte konnten nicht geladen werden:\n${loadErrors.join('\n')}`,
+    );
   }
 
   return {
@@ -131,11 +145,10 @@ function validateManifest(manifest) {
       throw new Error(`Folie ${index + 1} besitzt kein content-Feld.`);
     }
 
-    if (!slide.audio) {
-      const showtime = normalizeShowtime(slide.showtime);
-      if (!showtime) {
-        throw new Error(`Folie ${index + 1} besitzt weder audio noch ein gültiges showtime-Attribut.`);
-      }
+    const normalizedAudio = normalizeAudio(slide.audio);
+    const normalizedShowtime = normalizeShowtime(slide.showtime);
+    if (!normalizedAudio && !normalizedShowtime) {
+      throw new Error(`Folie ${index + 1} besitzt weder audio noch ein gültiges showtime-Attribut.`);
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Make the slide-change cue more robust and flexible by introducing a reusable bell synthesis API and falling back to the existing gong when the bell fails. 
- Export preset bell definitions so they can be reused from other modules. 
- Improve deck loading resilience by continuing when individual slide content fails to load and surfacing placeholder content and warnings instead of aborting.

### Description

- Updated `src/app.js` to import `playGlockeTone` and `playSlideChangeGong` and replaced the old direct `helleGlocke` call in `playSlideChangeCue` with `playGlockeTone` and a `try/catch` fallback to `playSlideChangeGong`, mapping config keys to the new API. 
- Reworked `src/glocke.js` to export bell presets (`helleGlocke`, `grosseGlocke`, `kleineGlocke`) and to add `playGlockeTone(context, preset, overrides)`, a parameterized bell synthesizer that uses the provided `AudioContext` and returns the tone duration. 
- Enhanced `src/loaders.js` build logic to wrap each `assetLoader.loadText` call in a `try/catch`, collect `loadErrors`, insert a Markdown placeholder into the slide `contentText` when loading fails, and emit a `console.warn` summarizing failures. 
- Tightened manifest validation in `validateManifest` to use `normalizeAudio` and `normalizeShowtime` and to error only when both are absent.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff8115ee8832ab27753c3848703ce)