### PR TITLE
Play end-of-presentation bell sequence and adjust auto-advance behavior

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ import {
     SLIDE_CHANGE_BELL_VOLUME,
     playSlideChangeGong,
 } from './gong.js';
-import {helleGlocke, playGlockeTone} from './glocke.js';
+import {grosseGlocke, helleGlocke, kleineGlocke, playGlockeTone} from './glocke.js';
 import {
     canPlayInAudioElement,
     inferAudioType,
@@ -499,16 +499,33 @@ function syncAutoSlideChangeForCurrentSlide() {
 
 async function handleSlidePlaybackCompleted() {
     setPlayButtonActive(false);
-    if (!state.autoAdvance || !state.deck || isSlideTransitionInProgress) {
+    if (!state.deck || isSlideTransitionInProgress) {
         return;
     }
 
-    if (state.currentIndex < state.deck.slides.length - 1) {
+    const isLastSlide = state.currentIndex >= state.deck.slides.length - 1;
+    if (isLastSlide) {
+        await playPresentationEndCueWithIndicator();
+        return;
+    }
+
+    if (state.autoAdvance) {
         await goToSlide(state.currentIndex + 1, {autoplay: true});
+    }
+}
+
+async function playPresentationEndCueWithIndicator() {
+    const cueDurationSeconds = playPresentationEndCue();
+    if (cueDurationSeconds <= 0) {
         return;
     }
 
-    playSlideChangeCueWithIndicator();
+    const indicatorToken = showSlideChangeCueIndicator();
+    window.setTimeout(() => {
+        restoreShowtimeCountdownAfterCue(indicatorToken);
+    }, cueDurationSeconds * 1000);
+
+    await delay(cueDurationSeconds * 1000);
 }
 
 async function initializeFromQueryParameters() {
@@ -622,6 +639,44 @@ function playSlideChangeCueWithIndicator() {
     }, bellDurationSeconds * 1000);
 
     return bellDurationSeconds;
+}
+
+function playPresentationEndCue() {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) {
+        return 0;
+    }
+
+    try {
+        if (!slideChangeCueAudioContext) {
+            slideChangeCueAudioContext = new AudioContextClass();
+        }
+        const context = slideChangeCueAudioContext;
+        if (context.state === 'suspended') {
+            context.resume().catch(() => {
+            });
+        }
+
+        const endCueBellVolume = Math.min(1, Math.max(0.0001, SLIDE_CHANGE_BELL_VOLUME / 4));
+        const durationHelle = playGlockeTone(context, helleGlocke, {loudness: endCueBellVolume});
+        const durationKleine = kleineGlocke.duration;
+        const durationGrosse = grosseGlocke.duration;
+
+        const totalDuration = durationHelle + durationKleine + durationGrosse;
+
+        window.setTimeout(() => {
+            playGlockeTone(context, kleineGlocke, {loudness: endCueBellVolume});
+        }, durationHelle * 1000);
+
+        window.setTimeout(() => {
+            playGlockeTone(context, grosseGlocke, {loudness: endCueBellVolume});
+        }, (durationHelle + durationKleine) * 1000);
+
+        return totalDuration;
+    } catch (error) {
+        console.debug('Presentation-End-Cue konnte nicht abgespielt werden.', error);
+        return 0;
+    }
 }
 
 function delay(durationMs) {


### PR DESCRIPTION
### Motivation
- Add a distinct audio cue when the presentation reaches the final slide so attendees get a clear end signal. 
- Ensure the slide-change indicator and showtime countdown are properly managed when the end cue plays. 
- Clarify auto-advance logic so advancing only happens when `state.autoAdvance` is enabled while still allowing the end cue to play on the last slide.

### Description
- Import additional bell assets `grosseGlocke` and `kleineGlocke` and reuse `helleGlocke` via `playGlockeTone` to implement a multi-bell end cue. 
- Add `playPresentationEndCue()` which creates/uses `AudioContext` to play `helle`, then `kleine`, then `grosse` bells in sequence at reduced volume and returns the total cue duration. 
- Add `playPresentationEndCueWithIndicator()` to show the slide-change indicator, restore the showtime countdown after the cue, and wait the cue duration before continuing. 
- Update `handleSlidePlaybackCompleted()` to detect the last slide and play the presentation end cue instead of attempting to advance, and only call `goToSlide()` when `state.autoAdvance` is enabled for non-final slides. 

### Testing
- Ran the existing automated unit/integration test suite with `npm test`, and the tests completed successfully. 
- Built the application (development build) to verify no runtime errors were introduced during the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d7f1aeb4832ab3a1f60ccc54a040)