### PR TITLE
Sprech-Emoji durch `speaking_head` SVG ersetzen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,7 @@ import {
     startSwipeTracking,
     updateSwipeTracking,
 } from './swipe.js';
-import {initializeIcons} from "./icons.js";
+import {initializeIcons, setIcon} from './icons.js';
 
 const state = createInitialState();
 let slideAdvanceTimer = null;
@@ -395,7 +395,7 @@ function renderSpeakingIndicator() {
     if (!elements.showtimeCountdown) {
         return;
     }
-    elements.showtimeCountdown.textContent = '🗣️';
+    setIcon(elements.showtimeCountdown, 'speaking_head');
     elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
     elements.showtimeCountdown.classList.add('is-speaking');
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -202,6 +202,17 @@ button:disabled {
     color: #6cc0ff;
 }
 
+.showtime-countdown.is-speaking svg {
+    width: 1.15em;
+    height: 1.15em;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.showtime-countdown.is-speaking svg path {
+    fill: currentColor;
+}
+
 input[type="url"],
 input[type="number"] {
     padding: 10px 12px;


### PR DESCRIPTION
### Motivation
- Die SVGs wurden in `src/icons.js` ausgelagert und das vorhandene sprechende Kopf-Icon `speaking_head` soll das bislang hardcodierte Emoji im Countdown ersetzen, damit Icons zentral verwaltet werden. 
- Die Anzeige muss weiterhin dynamisch gesetzt werden und am Ende der Audiowiedergabe wieder durch den Countdown/🔔-Marker ersetzt werden.

### Description
- Importiert `setIcon` aus `src/icons.js` und verwendet es in `renderSpeakingIndicator()` statt des Emojis (`🗣️`) um das `speaking_head` SVG zu setzen (`src/app.js`).
- Ergänzt Styles in `src/styles.css` damit das eingefügte SVG im Countdown passend skaliert und mit `currentColor` eingefärbt wird.
- Es wurden keine Änderungen am Ablauf der Zustandswechsel vorgenommen, die Entfernung des Speaking-Indicators und das Zurücksetzen auf den Countdown/Cue bleibt unverändert.

### Testing
- Statische Syntaxprüfung mit `node --check src/app.js` wurde ausgeführt und war erfolgreich.
- Statische Syntaxprüfung mit `node --check src/icons.js` wurde ausgeführt und war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4dfb7ce4c832ab61e88222aebdbc2)