### PR TITLE
Style speaking_head speech path in orange

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -213,6 +213,10 @@ button:disabled {
     fill: currentColor;
 }
 
+.showtime-countdown.is-speaking svg path.speak {
+    fill: #f59e0b;
+}
+
 input[type="url"],
 input[type="number"] {
     padding: 10px 12px;


### PR DESCRIPTION
### Motivation
- Ensure the `path` with class `speak` inside the `speaking_head` SVG renders in orange when the countdown is in the `.showtime-countdown.is-speaking` state.

### Description
- Added a specific CSS rule ` .showtime-countdown.is-speaking svg path.speak { fill: #f59e0b; }` to `src/styles.css` while keeping the existing generic `path` fill behavior.

### Testing
- No automated test suite is configured; the change was verified by inspecting the stylesheet with `rg`/`nl` and confirming the new rule is present and correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e34aa40c832a9780c9c60cf89dca)