### PR TITLE
Extract layout concerns into layout.js and refactor app initialization

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,15 @@ import {
     startSwipeTracking,
     updateSwipeTracking,
 } from './swipe.js';
-import {initializeIcons, setIcon} from './icons.js';
+import {initializeIcons} from './icons.js';
+import {
+    collectLayoutElements,
+    registerLayoutLifecycleHooks,
+    renderShowtimeCountdown as renderLayoutShowtimeCountdown,
+    renderShowtimeDash as renderLayoutShowtimeDash,
+    renderSpeakingIndicator as renderLayoutSpeakingIndicator,
+    updateTranscriptToggleButton,
+} from './layout.js';
 
 const state = createInitialState();
 let slideAdvanceTimer = null;
@@ -46,65 +54,67 @@ const tapState = {
     lastTapY: 0,
 };
 
-const elements = {
-    deckTitle: document.querySelector('#deck-title'),
-    slideCounter: document.querySelector('#slide-counter'),
-    sourceKind: document.querySelector('#source-kind'),
-    audioStatus: document.querySelector('#audio-status'),
-    errorBox: document.querySelector('#error-box'),
-    playerToolbar: document.querySelector('#player-toolbar'),
-    slideList: document.querySelector('#slide-list'),
-    slideStage: document.querySelector('#slide-stage'),
-    gotoInput: document.querySelector('#goto-input'),
-    showtimeCountdown: document.querySelector('#showtime-countdown'),
-    transcriptToggleBtn: document.querySelector('#transcript-toggle-btn'),
-    transcriptPanel: document.querySelector('#transcript-panel'),
-    transcriptHint: document.querySelector('#transcript-hint'),
-    transcriptText: document.querySelector('#transcript-text'),
-    transcriptAudioPlayer: document.querySelector('#transcript-audio-player'),
-    autoplayNextCheckbox: document.querySelector('#autoplay-next-checkbox'),
-    remoteUrlInput: document.querySelector('#remote-url-input'),
-    zipInput: document.querySelector('#zip-input'),
-    pickDirectoryBtn: document.querySelector('#pick-directory-btn'),
-    loadRemoteBtn: document.querySelector('#load-remote-btn'),
-    firstBtn: document.querySelector('#first-btn'),
-    prevBtn: document.querySelector('#prev-btn'),
-    playBtn: document.querySelector('#play-btn'),
-    pauseBtn: document.querySelector('#pause-btn'),
-    stopBtn: document.querySelector('#stop-btn'),
-    nextBtn: document.querySelector('#next-btn'),
-    lastBtn: document.querySelector('#last-btn'),
-    gotoBtn: document.querySelector('#goto-btn'),
-};
-
-const audioController = new AudioController({
-    onStatusChange(status) {
-        elements.audioStatus.textContent = status;
-        if (status.startsWith('Spielt')) {
-            renderSpeakingIndicator();
-        } else if (!showtimeCountdownInterval) {
-            renderShowtimeDash();
-        }
-    },
-    async onEnded() {
-        await handleSlidePlaybackCompleted();
-    },
-    onFallbackTimerStart(seconds) {
-        if (!state.autoAdvance) {
-            return;
-        }
-        setPlayButtonActive(true);
-        startShowtimeCountdown(null, {seconds});
-    },
-    onAudioIssue(message) {
-        showError(`⚠️ ${message}`);
-    },
-});
-
-initializeIcons()
+const {elements, audioController} = await initializeApplication();
+registerLifecycleHooks();
+initializeIcons();
 bindEvents();
 refreshUi();
 await initializeFromQueryParameters();
+
+async function initializeApplication() {
+    const resolvedElements = collectLayoutElements();
+    const resolvedAudioController = createAudioController(resolvedElements);
+
+    return {
+        elements: resolvedElements,
+        audioController: resolvedAudioController,
+    };
+}
+
+function createAudioController(resolvedElements) {
+    return new AudioController({
+        onStatusChange(status) {
+            resolvedElements.audioStatus.textContent = status;
+            if (status.startsWith('Spielt')) {
+                renderSpeakingIndicator();
+            } else if (!showtimeCountdownInterval) {
+                renderShowtimeDash();
+            }
+        },
+        async onEnded() {
+            await handleSlidePlaybackCompleted();
+        },
+        onFallbackTimerStart(seconds) {
+            if (!state.autoAdvance) {
+                return;
+            }
+            setPlayButtonActive(true);
+            startShowtimeCountdown(null, {seconds});
+        },
+        onAudioIssue(message) {
+            showError(`⚠️ ${message}`);
+        },
+    });
+}
+
+function registerLifecycleHooks() {
+    registerLayoutLifecycleHooks({
+        onVisibilityHidden() {
+            resetSwipeState(swipeState);
+            resetTapState();
+        },
+        onBeforeUnload() {
+            cleanupApplication();
+        },
+    });
+}
+
+function cleanupApplication() {
+    clearSlideAdvanceTimer();
+    clearShowtimeCountdown();
+    clearTransitionUnlockTimer();
+    nonAudioPlaybackRemainingSeconds = null;
+}
 
 function bindEvents() {
     elements.pickDirectoryBtn.addEventListener('click', async () => {
@@ -373,32 +383,15 @@ function getSlideShowtimeSeconds(slide) {
 }
 
 function renderShowtimeCountdown(value) {
-    if (!elements.showtimeCountdown) {
-        return;
-    }
-
-    const safeValue = Math.max(0, Math.floor(value));
-    elements.showtimeCountdown.textContent = String(safeValue);
-    elements.showtimeCountdown.classList.remove('is-speaking');
-    elements.showtimeCountdown.classList.toggle('is-safe', safeValue > 3);
-    elements.showtimeCountdown.classList.toggle('is-danger', safeValue <= 3);
+    renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
 }
 
 function renderShowtimeDash() {
-    if (!elements.showtimeCountdown) {
-        return;
-    }
-    elements.showtimeCountdown.textContent = '–';
-    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking');
+    renderLayoutShowtimeDash(elements.showtimeCountdown);
 }
 
 function renderSpeakingIndicator() {
-    if (!elements.showtimeCountdown) {
-        return;
-    }
-    setIcon(elements.showtimeCountdown, 'speaking_head');
-    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe');
-    elements.showtimeCountdown.classList.add('is-speaking');
+    renderLayoutSpeakingIndicator(elements.showtimeCountdown);
 }
 
 function showSlideChangeCueIndicator() {
@@ -842,12 +835,7 @@ async function toggleTranscriptPanel() {
 
 function setTranscriptPanelVisibility(isVisible) {
     elements.transcriptPanel.classList.toggle('hidden', !isVisible);
-    elements.transcriptToggleBtn.setAttribute('aria-expanded', String(isVisible));
-    elements.transcriptToggleBtn.setAttribute('aria-pressed', String(isVisible));
-    elements.transcriptToggleBtn.classList.toggle('is-open', isVisible);
-    const tooltipText = isVisible ? 'Audiotext ausblenden' : 'Audiotext einblenden';
-    elements.transcriptToggleBtn.title = tooltipText;
-    elements.transcriptToggleBtn.setAttribute('aria-label', tooltipText);
+    updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
 }
 
 function hideTranscriptPanel() {

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,104 @@
+import {setIcon} from './icons.js';
+
+const ELEMENT_SELECTORS = {
+    deckTitle: '#deck-title',
+    slideCounter: '#slide-counter',
+    sourceKind: '#source-kind',
+    audioStatus: '#audio-status',
+    errorBox: '#error-box',
+    playerToolbar: '#player-toolbar',
+    slideList: '#slide-list',
+    slideStage: '#slide-stage',
+    gotoInput: '#goto-input',
+    showtimeCountdown: '#showtime-countdown',
+    transcriptToggleBtn: '#transcript-toggle-btn',
+    transcriptPanel: '#transcript-panel',
+    transcriptHint: '#transcript-hint',
+    transcriptText: '#transcript-text',
+    transcriptAudioPlayer: '#transcript-audio-player',
+    autoplayNextCheckbox: '#autoplay-next-checkbox',
+    remoteUrlInput: '#remote-url-input',
+    zipInput: '#zip-input',
+    pickDirectoryBtn: '#pick-directory-btn',
+    loadRemoteBtn: '#load-remote-btn',
+    firstBtn: '#first-btn',
+    prevBtn: '#prev-btn',
+    playBtn: '#play-btn',
+    pauseBtn: '#pause-btn',
+    stopBtn: '#stop-btn',
+    nextBtn: '#next-btn',
+    lastBtn: '#last-btn',
+    gotoBtn: '#goto-btn',
+};
+
+export function collectLayoutElements(root = document) {
+    return Object.entries(ELEMENT_SELECTORS).reduce((elements, [name, selector]) => {
+        const element = root.querySelector(selector);
+        if (!element) {
+            throw new Error(`Layout-Element fehlt: ${selector}`);
+        }
+        elements[name] = element;
+        return elements;
+    }, {});
+}
+
+export function renderShowtimeCountdown(element, value) {
+    if (!element) {
+        return;
+    }
+
+    const safeValue = Math.max(0, Math.floor(value));
+    element.textContent = String(safeValue);
+    element.classList.remove('is-speaking');
+    element.classList.toggle('is-safe', safeValue > 3);
+    element.classList.toggle('is-danger', safeValue <= 3);
+}
+
+export function renderShowtimeDash(element) {
+    if (!element) {
+        return;
+    }
+
+    element.textContent = '–';
+    element.classList.remove('is-danger', 'is-safe', 'is-speaking');
+}
+
+export function renderSpeakingIndicator(element) {
+    if (!element) {
+        return;
+    }
+
+    setIcon(element, 'speaking_head');
+    element.classList.remove('is-danger', 'is-safe');
+    element.classList.add('is-speaking');
+}
+
+export function updateTranscriptToggleButton(button, isVisible) {
+    button.setAttribute('aria-expanded', String(isVisible));
+    button.setAttribute('aria-pressed', String(isVisible));
+    button.classList.toggle('is-open', isVisible);
+
+    const tooltipText = isVisible ? 'Audiotext ausblenden' : 'Audiotext einblenden';
+    button.title = tooltipText;
+    button.setAttribute('aria-label', tooltipText);
+}
+
+export function registerLayoutLifecycleHooks({onVisibilityHidden, onBeforeUnload} = {}) {
+    const handleVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') {
+            onVisibilityHidden?.();
+        }
+    };
+
+    const handleBeforeUnload = () => {
+        onBeforeUnload?.();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+}


### PR DESCRIPTION
### Motivation
- Decouple DOM layout and lifecycle concerns from the main application logic to centralize element selection and countdown/render helpers.
- Move layout-related rendering (showtime countdown, dash, speaking indicator) and transcript toggle UI logic into a dedicated module to simplify `app.js` and improve testability.

### Description
- Added `src/layout.js` which defines `ELEMENT_SELECTORS`, `collectLayoutElements`, `renderShowtimeCountdown`, `renderShowtimeDash`, `renderSpeakingIndicator`, `updateTranscriptToggleButton`, and `registerLayoutLifecycleHooks` to encapsulate layout responsibilities.
- Replaced the in-file `elements` map in `src/app.js` with `await initializeApplication()` which uses `collectLayoutElements` and returns `elements` and an `AudioController` instance created by `createAudioController`.
- Extracted lifecycle hook registration into `registerLifecycleHooks()` in `app.js` and added `cleanupApplication()` to centralize timer and state cleanup logic.
- Replaced direct rendering and transcript toggle DOM manipulation in `app.js` with calls into the new layout helpers (`renderLayoutShowtimeCountdown`, `renderLayoutShowtimeDash`, `renderLayoutSpeakingIndicator`, `updateTranscriptToggleButton`) and updated imports accordingly.

### Testing
- Ran the repository test suite with `npm test`, and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ed7494c0832a8ee9238b84829b1b)