### PR TITLE
Korrigiere Pfeiltasten-Navigation (Links/ Rechts)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -201,8 +201,8 @@ function bindEvents() {
         if (event.target instanceof HTMLInputElement) {
             return;
         }
-        if (event.key === 'ArrowRight') await goToSlide(state.currentIndex - 1);
-        if (event.key === 'ArrowLeft') await goToSlide(state.currentIndex + 1);
+        if (event.key === 'ArrowLeft') await goToSlide(state.currentIndex - 1);
+        if (event.key === 'ArrowRight') await goToSlide(state.currentIndex + 1);
         if (event.key === 'Home') await goToSlide(0);
         if (event.key === 'End') await goToSlide(state.deck?.slides.length - 1 ?? -1);
         if (event.key === ' ') {


### PR DESCRIPTION
### Motivation
- Die Tastaturnavigation soll mit den Swipe-Gesten und den Vorgaben übereinstimmen, sodass `ArrowLeft` zur vorherigen und `ArrowRight` zur nächsten Folie navigiert.

### Description
- Angepasst: In der `keydown`-Behandlung innerhalb von `bindEvents` in `src/app.js` wurden die Handler vertauscht, sodass `ArrowLeft` jetzt `goToSlide(state.currentIndex - 1)` und `ArrowRight` jetzt `goToSlide(state.currentIndex + 1)` aufruft.

### Testing
- Automatischer Check `node --check src/app.js` wurde erfolgreich ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51d5587f8832a912e6c4f23bde39d)