### PR TITLE
Fix unreliable mouse single-click toggle on slide stage

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -57,7 +57,6 @@ let hasPresentationStarted = false;
 let singleTouchActionTimer = null;
 let singleClickActionTimer = null;
 let lastTouchTapTimestamp = 0;
-let lastTouchInteractionTimestamp = 0;
 
 await initApp();
 
@@ -258,7 +257,6 @@ function handleTouchStart(event) {
         return;
     }
     const touch = event.touches[0];
-    lastTouchInteractionTimestamp = Date.now();
     startSwipeTracking(swipeState, touch);
 }
 
@@ -275,7 +273,6 @@ async function handleTouchEnd(event) {
         resetSwipeState(swipeState);
         return;
     }
-    lastTouchInteractionTimestamp = Date.now();
 
     const changedTouch = event.changedTouches?.[0];
     const {isHorizontalSwipe, isVerticalSwipe, horizontalDistance, verticalDistance} = finishSwipe(swipeState, changedTouch);
@@ -319,11 +316,19 @@ async function handleTouchEnd(event) {
     scheduleSingleTouchToggle();
 }
 
+function isTouchGeneratedClickEvent(event) {
+    if (!(event instanceof MouseEvent)) {
+        return false;
+    }
+
+    return event.sourceCapabilities?.firesTouchEvents === true;
+}
+
 async function handleStageClick(event) {
     if (!state.deck || state.currentIndex < 0 || isSlideTransitionInProgress) {
         return;
     }
-    if (Date.now() - lastTouchInteractionTimestamp <= DOUBLE_TAP_INTERVAL_MS * 2) {
+    if (isTouchGeneratedClickEvent(event)) {
         return;
     }
     if (isInteractiveControlTarget(event.target)) {


### PR DESCRIPTION
### Motivation
- Desktop single left-clicks on the slide stage were sometimes suppressed by a purely time-based touch-suppression heuristic, causing unreliable mouse toggles. 
- The goal is to keep touch-duplicate filtering but allow native mouse clicks to reliably toggle play/pause.

### Description
- Replaced the time-based suppression with an explicit detector `isTouchGeneratedClickEvent(event)` that checks `event instanceof MouseEvent` and `event.sourceCapabilities?.firesTouchEvents` in `src/app.js`.
- Updated `handleStageClick` to skip only touch-generated synthetic click events and otherwise allow real mouse single-clicks to trigger `togglePresentationByTouch()`.
- Removed usage of the `lastTouchInteractionTimestamp` suppression logic and its updates in touch handlers to avoid blocking native mouse clicks.

### Testing
- Ran a syntax check with `node --check src/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e522f6f594832aaec50bdb8beed09e)