### PR TITLE
Fix click-to-play after manual slide navigation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -844,16 +844,31 @@ async function togglePresentationByTouch() {
         return;
     }
 
-    if (elements.audioStatus.textContent === 'Pausiert') {
-        await resumePresentation();
+    if (!isPresentationRunning()) {
+        if (elements.audioStatus.textContent === 'Pausiert') {
+            await resumePresentation();
+            return;
+        }
+        await playCurrentSlide();
         return;
     }
 
     await pausePresentation();
 }
 
+function isPresentationRunning() {
+    if (nonAudioPlaybackRemainingSeconds !== null) {
+        return true;
+    }
+    return elements.audioStatus.textContent.startsWith('Spielt');
+}
+
 async function pausePresentation() {
     if (!hasPresentationStarted) {
+        return;
+    }
+
+    if (!isPresentationRunning()) {
         return;
     }
 
@@ -864,6 +879,10 @@ async function pausePresentation() {
     clearShowtimeCountdown();
     nonAudioPlaybackRemainingSeconds = null;
     setPlayButtonActive(false);
+
+    if (elements.audioStatus.textContent === 'Pausiert') {
+        return;
+    }
 
     if (pausedNonAudioRemainingSeconds !== null) {
         elements.audioStatus.textContent = 'Pausiert';


### PR DESCRIPTION
### Motivation
- After navigating slides manually (e.g. with ArrowRight) the viewer could end up in a stopped state where clicking the stage wrongly executed pause logic instead of restarting playback.  
- The goal is to restore the expected behavior that a click on the stage starts playback when nothing is running and resumes when the state is `Pausiert`.

### Description
- Update `togglePresentationByTouch()` to treat the non-running state as a start action and to call `resumePresentation()` when `elements.audioStatus.textContent` equals `'Pausiert'`, otherwise call `playCurrentSlide()`; keep pause behavior when the presentation is actually running.  
- Introduce `isPresentationRunning()` which returns true when `nonAudioPlaybackRemainingSeconds` is non-null or when `elements.audioStatus.textContent` starts with `'Spielt'`.  
- Make `pausePresentation()` a no-op when nothing is running and avoid flipping into a paused state on empty clicks.  
- All changes are contained in `src/app.js` and preserve existing play/pause UI updates by reusing `setPlayButtonActive()` and existing audio controller flows.

### Testing
- Performed a syntax check with `node --check src/app.js` which succeeded.  
- No other automated tests exist in the repository; the change was committed after the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5262c9294832aabfc91b044879df2)