### PR TITLE
Centralize CDN dependency URLs via import map in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Slideshow Viewer</title>
     <link rel="stylesheet" href="./src/styles.css">
+    <script type="importmap">
+      {
+        "imports": {
+          "marked": "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js",
+          "jszip": "https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm"
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="app-shell">

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -22,7 +22,7 @@ export async function loadDeckFromDirectory() {
 }
 
 export async function loadDeckFromZip(file) {
-  const { default: JSZip } = await import('https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm');
+  const { default: JSZip } = await import('jszip');
   const zip = await JSZip.loadAsync(await file.arrayBuffer());
   const manifestEntry = zip.file('slides.json');
   if (!manifestEntry) {

--- a/src/wiki-parser.js
+++ b/src/wiki-parser.js
@@ -1,4 +1,4 @@
-import { marked } from 'https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js';
+import { marked } from 'marked';
 
 export function renderSlideContent(slide, assetResolver) {
   const raw = slide.contentText ?? '';


### PR DESCRIPTION
### Motivation
- Keep third-party CDN URLs and versions in a single, visible location to simplify updates and audits. 
- Avoid scattering literal CDN specifiers through multiple modules so imports can use bare specifiers. 
- Align with the project dependency policy that treats CDN imports as first-class third-party dependencies.

### Description
- Add an `importmap` to `index.html` that maps the specifier `marked` to `https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js` and `jszip` to `https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm`.
- Replace the hard-coded CDN import in `src/wiki-parser.js` with `import { marked } from 'marked';` so the browser resolves it from the import map.
- Replace the dynamic CDN import in `src/loaders.js` with `await import('jszip')` so the import map centralizes the URL/version.

### Testing
- Ran `node --check src/wiki-parser.js` and it succeeded. 
- Ran `node --check src/loaders.js` and it succeeded. 
- Ran `node --check src/app.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52afafec4832ab7ae4d79d1b2c30a)