### PR TITLE
Sanitize rendered slide HTML with DOMPurify

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Eingeschränkt:
 Aktuell werden folgende Bibliotheken verwendet:
 
 * `marked` (Markdown Parser)
+* `DOMPurify` (Sanitizing von gerendertem HTML)
 * `JSZip` (ZIP/SLD Verarbeitung)
 
 👉 Details siehe:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -35,7 +35,33 @@ SOFTWARE.
 
 ---
 
-## 2. JSZip
+## 2. DOMPurify
+
+- **Name:** DOMPurify
+- **Version:** 3.0.6 (loaded via CDN)
+- **Source:** https://github.com/cure53/DOMPurify
+- **License:** Apache-2.0 OR MPL-2.0
+- **Usage in this project:** Apache-2.0 license option
+
+### License Text (Apache-2.0)
+
+Copyright 2014-2026 Cure53 and other contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+## 3. JSZip
 
 - **Name:** JSZip
 - **Version:** 3.10.1 (loaded via CDN)

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script type="importmap">
       {
         "imports": {
+          "dompurify": "https://cdn.jsdelivr.net/npm/dompurify@3.0.6/+esm",
           "marked": "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js",
           "jszip": "https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm"
         }

--- a/src/wiki-parser.js
+++ b/src/wiki-parser.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 
 export function renderSlideContent(slide, assetResolver) {
@@ -5,7 +6,7 @@ export function renderSlideContent(slide, assetResolver) {
   const format = (slide.format || inferFormat(slide.contentPath)).toLowerCase();
 
   if (format === 'wm') {
-    return renderWikiMarkup(raw, assetResolver);
+    return sanitizeSlideHtml(renderWikiMarkup(raw, assetResolver));
   }
 
   const renderer = new marked.Renderer();
@@ -21,7 +22,14 @@ export function renderSlideContent(slide, assetResolver) {
     return `<img src="${resolved}" alt="${alt}"${titleAttr}>`;
   };
 
-  return marked.parse(raw, { renderer });
+  const rendered = marked.parse(raw, { renderer });
+  return sanitizeSlideHtml(rendered);
+}
+
+function sanitizeSlideHtml(html) {
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true }
+  });
 }
 
 export function inferFormat(path = '') {


### PR DESCRIPTION
### Motivation

* Slides can be loaded from remote sources and the project used `marked` to render Markdown, which leaves an XSS vector if rendered HTML is inserted unsanitized.
* The change aims to close that gap by sanitizing final rendered HTML for both Markdown and the custom wiki markup while keeping expected formatting.

### Description

* Add `dompurify` to the browser import map so the runtime library is available in the browser via CDN (`3.0.6`).
* Require and use `DOMPurify` in `src/wiki-parser.js` and introduce a `sanitizeSlideHtml` helper that calls `DOMPurify.sanitize(html, { USE_PROFILES: { html: true } })`.
* Call the sanitizer for both code paths: after `marked.parse(...)` for Markdown and after `renderWikiMarkup(...)` for wiki markup before returning slide HTML.
* Update `README.md` and `THIRD_PARTY_NOTICES.md` to document the new dependency and its license.

### Testing

* Ran `node --check src/wiki-parser.js` to validate the modified file and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52d0b70e4832aa7c2ba7dda19b1e3)