### PR TITLE
docs: harmonize project documentation links and MIT compliance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Das Projekt ist bewusst minimal gehalten:
 * **Kein Node.js erforderlich**
 * **Keine Backend-Komponenten**
 
+Eine detaillierte Modulbeschreibung steht in [`docs/architecture.md`](docs/architecture.md).
+
 Technologie:
 
 * HTML + CSS + Vanilla JavaScript
@@ -156,7 +158,7 @@ Eingeschränkt:
 ├── src/
 │   ├── app.js
 │   ├── loaders.js
-│   ├── parser.js
+│   ├── wiki-parser.js
 │   ├── audio.js
 │   └── ...
 ├── docs/
@@ -166,6 +168,23 @@ Eingeschränkt:
 ├── THIRD_PARTY_NOTICES.md
 └── .github/workflows/
 ```
+
+---
+
+
+## 📚 Dokumentation
+
+Eine zentrale Übersicht aller Doku-Teile findest du in [`docs/README.md`](docs/README.md).
+
+Direktlinks:
+
+* [Architektur](docs/architecture.md)
+* [Slideshow erstellen](docs/createslideshow.md)
+* [Manifestformat](docs/manifest.md)
+* [SLD-Spezifikation](docs/sld-spec.md)
+* [Dependency Policy](docs/dependency-policy.md)
+* [License Review Checklist](docs/license-review-checklist.md)
+* [Roadmap](docs/roadmap.md)
 
 ---
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third Party Notices
 
-This project uses the following third-party libraries:
+This project uses the following third-party components (libraries and assets):
 
 ---
 
@@ -93,8 +93,42 @@ SOFTWARE.
 
 ---
 
+
+## 4. Speaking Head Icon (Twemoji via SVG Repo)
+
+- **Name:** speaking_head icon (Twemoji-derived asset)
+- **Version:** asset snapshot (downloaded 2026-04-16)
+- **Source:** https://www.svgrepo.com/svg/407507/speaking-head
+- **Original project:** https://github.com/twitter/twemoji
+- **License:** MIT License
+- **Usage in this project:** adapted SVG used in `src/icons.js`
+
+### License Text (MIT)
+
+Copyright Twitter, Inc and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 ## Notes
 
 - All third-party libraries are loaded via CDN (jsDelivr).
 - No local modifications to third-party source code are made.
-- This document ensures compliance with attribution requirements of the MIT license.
+- This document supports compliance with attribution requirements of MIT/Apache licensed third-party components used in the project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Dokumentationsübersicht
+
+Diese Übersicht bündelt die Projekt-Dokumentation und reduziert Redundanzen.
+
+## Einstieg
+
+- [README (Projektüberblick)](../README.md)
+- [Architektur](./architecture.md)
+- [Slideshow erstellen](./createslideshow.md)
+
+## Format- und Schema-Dokumente
+
+- [Manifestformat (`slides.json`)](./manifest.md)
+- [SLD-Formatspezifikation](./sld-spec.md)
+
+## Governance, Lizenzen und Abhängigkeiten
+
+- [Dependency Policy](./dependency-policy.md)
+- [License Review Checklist](./license-review-checklist.md)
+- [Third Party Notices](../THIRD_PARTY_NOTICES.md)
+- [Projektlizenz (MIT)](../LICENSE)
+
+## Planung
+
+- [Roadmap](./roadmap.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,72 +2,64 @@
 
 ## Grundidee
 
-Die Anwendung ist bewusst als reine statische Browser-Anwendung aufgebaut.
+Die Anwendung ist bewusst als rein statische Browser-Anwendung aufgebaut:
 
 - kein Backend
 - keine Datenbank
 - deploymentfähig auf GitHub Pages
-- lokale Nutzung per Verzeichnis oder ZIP
+- lokale Nutzung per Verzeichnis oder SLD/ZIP
 
 ## Module
 
 ### `src/app.js`
 
-Zentrale UI-Logik:
+Zentrale UI- und Ablaufsteuerung:
 
-- Event-Handler
-- Foliennavigation
-- Laden der Slideshow
-- Zusammenspiel von Renderer und Audio
+- Event-Handling und Navigation
+- Laden der Slideshow über die Loader
+- Synchronisation von Audio, Showtime und UI-Status
 
 ### `src/loaders.js`
 
 Abstraktion für Datenquellen:
 
 - lokales Verzeichnis
-- lokales ZIP
+- lokales SLD/ZIP
 - Remote-Manifest
-- Remote-ZIP
+- Remote-SLD/ZIP
 
-Die Loader liefern ein einheitliches Deck-Objekt mit:
-
-- Metadaten
-- geladenen Folieninhalten
-- Asset-Resolver
-- Audiozugriff
+Die Loader liefern ein einheitliches Deck-Objekt mit Folieninhalt, Metadaten und Asset-Resolver.
 
 ### `src/wiki-parser.js`
 
 Renderer für:
 
-- Markdown via `marked`
+- Markdown (`marked` + `DOMPurify`)
 - vereinfachtes Wiki-Markup (`.wm`)
 
-### `src/audio.js`
+### `src/audio.js` und `src/transcript.js`
 
-Audio-Abstraktion für:
+Audio- und Transkriptabstraktion für:
 
-- Browser-TTS
-- SSML-Abbau auf sprechbaren Text
-- MP3-Wiedergabe
+- Browser-TTS (Text/SSML)
+- MP3-/Audio-Playback
+- Fallbacks und Anzeige von Audioinhalt im Transcript-Panel
+
+### `src/layout.js`, `src/icons.js`, `src/swipe.js`, `src/error.js`
+
+UI-Helfermodule für:
+
+- Layout/Toolbar/Countdown
+- Icon-Initialisierung
+- Touch-/Swipe-Bedienung
+- konsistente Fehlerdarstellung
 
 ## Wichtige technische Entscheidungen
 
-### 1. ZIP-Unterstützung im Browser
-
-ZIP-Dateien werden im Browser mit `JSZip` gelesen. Dadurch bleibt die App serverlos.
-
-### 2. Lokales Verzeichnis
-
-Das Öffnen lokaler Verzeichnisse nutzt die File System Access API. Das ist praktisch, aber nicht in jedem Browser verfügbar.
-
-### 3. Audio
-
-Für MP3 nutzt das Gerüst absichtlich die eingebaute Browser-Audiowiedergabe statt sich an eine alte, archivierte Spezialbibliothek zu koppeln. Popcorn.js wurde von Mozilla archiviert und ist seit dem 29. Juni 2018 read-only. citeturn331253search2turn331253search6
-
-### 4. SSML
-
-Die Browser-TTS-APIs sind uneinheitlich. Deshalb behandelt das Gerüst SSML pragmatisch: Tags werden entfernt und der verbleibende Text gesprochen. Das ist als Startpunkt brauchbar, aber noch kein vollständiger SSML-Interpreter.
+1. **ZIP-Unterstützung im Browser:** SLD/ZIP werden im Browser mit `JSZip` gelesen.
+2. **Lokales Verzeichnis:** Öffnen über File System Access API (v. a. in Chromium-basierten Browsern).
+3. **Audio-Wiedergabe:** Native Browser-Audio- und TTS-APIs statt zusätzlicher Legacy-Abhängigkeiten.
+4. **SSML-Strategie:** Der Viewer nutzt eine pragmatische SSML-Verarbeitung als robusten Startpunkt.
 
 ## Erweiterungspunkte
 

--- a/docs/createslideshow.md
+++ b/docs/createslideshow.md
@@ -4,6 +4,10 @@ Diese Anleitung beschreibt, wie eine Slideshow für den Viewer aufgebaut wird.
 
 Ziel ist es, mit minimalem Aufwand einen Foliensatz zu erstellen, der aus Text (Markdown oder Wiki) und optionalem Audio besteht.
 
+> Ergänzende Referenzen:
+> - Detaillierte Feldbeschreibung: [`docs/manifest.md`](./manifest.md)
+> - Formatrahmen: [`docs/sld-spec.md`](./sld-spec.md)
+
 ---
 
 ## Grundprinzip

--- a/index.html
+++ b/index.html
@@ -22,28 +22,31 @@
       <div class="project-intro">
         <p class="project-links">
           Quellen:
-                <a href="https://github.com/Huluvu424242/slideshow-viewer" target="_blank" rel="noreferrer">
-                    slideshow-viewer
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer" target="_blank" rel="noreferrer">
+                    sld-slideshow-viewer
                 </a>,
                 <a href="https://huluvu424242.github.io/foile-pile/" target="_blank" rel="noreferrer">
                     Präsentationen (Sammlung)
-                </a>,
+                </a>
         </p>
         <p class="project-links">
           Dokumentation:
-                <a href="https://github.com/Huluvu424242/slideshow-viewer/tree/master/README.md" target="_blank"
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/README.md" target="_blank"
+                   rel="noreferrer">Doku-Index</a>,
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/README.md" target="_blank"
                    rel="noreferrer">README</a>,
-                <a href="https://github.com/Huluvu424242/slideshow-viewer/tree/master/docs/createslideshow.md"
-                   target="_blank" rel="noreferrer">Create Slideshow</a>
-                <a href="https://github.com/Huluvu424242/slideshow-viewer/tree/master/docs/architecture.md"
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/createslideshow.md"
+                   target="_blank" rel="noreferrer">Create Slideshow</a>,
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/architecture.md"
                    target="_blank" rel="noreferrer">Architektur</a>,
-                <a href="https://github.com/Huluvu424242/slideshow-viewer/tree/master/docs/manifest.md" target="_blank"
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/manifest.md" target="_blank"
                    rel="noreferrer">Manifest</a>,
-                <a href="https://github.com/Huluvu424242/slideshow-viewer/tree/master/docs/roadmap.md" target="_blank"
-                   rel="noreferrer">Roadmap</a>,
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/sld-spec.md" target="_blank"
+                   rel="noreferrer">SLD-Spec</a>,
+                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/roadmap.md" target="_blank"
+                   rel="noreferrer">Roadmap</a>
         </p>
       </div>
-    </p>
 
         <section class="panel">
           <h2>Quelle laden</h2>


### PR DESCRIPTION
### Motivation

- Die Projektdokumentation war teilweise redundant und enthielt veraltete Pfade/Links, wodurch Einstieg und Navigation erschwertet wurden.
- Lizenz- und Attributionsinformationen für ein eingebettetes SVG-Asset fehlten in `THIRD_PARTY_NOTICES.md`, was die MIT-Compliance unvollständig machte.

### Description

- Fügt einen zentralen Doku-Index `docs/README.md` hinzu und ergänzt `README.md` mit Direktlinks zu den Kern-Dokumenten und einer Verweiszeile auf `docs/architecture.md`.
- Aktualisiert `docs/architecture.md` und `docs/createslideshow.md`, um Modulbeschreibungen, Format-Referenzen und Querverweise konsistent zum aktuellen Code zu machen.
- Korrigiert In-App/Dashboard-Links in `index.html` (Repository-Pfade und Doku-Links) und bereinigt die kleine HTML-Strukturunstimmigkeit im Linkblock.
- Erweitert `THIRD_PARTY_NOTICES.md` um Attribution und MIT-Lizenztext für das Twemoji-/SVG-basierte `speaking_head`-Icon und präzisiert die Formulierung der Notizen.

### Testing

- `for f in src/*.js; do node --check "$f"; done` wurde ausgeführt und alle geparsten JS-Dateien sind syntaktisch korrekt (Erfolg).
- Ein Link-Validierungs-Skript für lokale Markdown-Links (`python` snippet) prüfte alle referenzierten lokalen Doku-Dateien und meldete keine fehlenden Ziele (Erfolg).
- Ein Skript zur Konsistenzprüfung zwischen erkannten CDN-Abhängigkeiten und `THIRD_PARTY_NOTICES.md` wurde ausgeführt und bestätigte, dass alle erkannten Abhängigkeiten dokumentiert sind (Erfolg).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53305c2d0832abb0ec75ccbc2bd8b)