### PR TITLE
Add help icon and toggleable controls help panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,10 +158,32 @@
             <label class="checkbox-inline">
               <input id="autoplay-next-checkbox" type="checkbox" checked>
               <span>Nächste Folie automatisch</span>
+              <button
+                id="help-toggle-btn"
+                class="icon-btn icon-btn--help"
+                type="button"
+                title="Steuerungshilfe anzeigen"
+                aria-label="Steuerungshilfe anzeigen"
+                aria-expanded="false"
+                data-icon="help"
+              >
+              </button>
             </label>
           </div>
         </header>
         <div id="error-box" class="error-box error-box--stage hidden" role="alert"></div>
+        <section id="help-panel" class="help-panel hidden" aria-live="polite">
+          <h3>Steuerungshilfe</h3>
+          <p>Diese Befehle stehen für Folienwechsel und Wiedergabe zur Verfügung:</p>
+          <ul>
+            <li><strong>Buttons:</strong> Erste, Vorherige, Nächste, Letzte Folie; Abspielen, Pause, Stop.</li>
+            <li><strong>Tastatur:</strong> ← / → für vorherige bzw. nächste Folie, Home für erste, Ende für letzte Folie, Leertaste startet die aktuelle Folie.</li>
+            <li><strong>Klick im Folienbereich:</strong> Einfachklick startet/pausiert die Präsentation.</li>
+            <li><strong>Doppelklick im Folienbereich:</strong> Scrollt zurück an den Anfang der Folie.</li>
+            <li><strong>Touch-Gesten:</strong> Wischen links/rechts wechselt Folien, Wischen nach oben/unten zeigt/versteckt den Audiotext, Tippen startet/pausiert.</li>
+            <li><strong>Gehe zu:</strong> Foliennummer eingeben und mit <em>Los</em> direkt springen.</li>
+          </ul>
+        </section>
 
         <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
           <h3>Audioinhalt der aktuellen Folie</h3>

--- a/src/app.js
+++ b/src/app.js
@@ -183,6 +183,10 @@ function bindEvents() {
         state.autoAdvance = elements.autoplayNextCheckbox.checked;
         syncAutoSlideChangeForCurrentSlide();
     });
+    elements.helpToggleBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        toggleHelpPanel();
+    });
     elements.transcriptToggleBtn.addEventListener('click', async (event) => {
         event.preventDefault();
         const previousAutoAdvance = state.autoAdvance;
@@ -1004,6 +1008,19 @@ async function toggleTranscriptPanel() {
 function setTranscriptPanelVisibility(isVisible) {
     elements.transcriptPanel.classList.toggle('hidden', !isVisible);
     updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
+}
+
+function isHelpPanelOpen() {
+    return !elements.helpPanel.classList.contains('hidden');
+}
+
+function toggleHelpPanel() {
+    const shouldOpen = !isHelpPanelOpen();
+    elements.helpPanel.classList.toggle('hidden', !shouldOpen);
+    elements.helpToggleBtn.setAttribute('aria-expanded', String(shouldOpen));
+    const tooltipText = shouldOpen ? 'Steuerungshilfe ausblenden' : 'Steuerungshilfe anzeigen';
+    elements.helpToggleBtn.title = tooltipText;
+    elements.helpToggleBtn.setAttribute('aria-label', tooltipText);
 }
 
 function hideTranscriptPanel() {

--- a/src/icons.js
+++ b/src/icons.js
@@ -135,6 +135,19 @@ export const ICONS = Object.freeze({
     </svg>
   `,
     /*
+     * Icon: help
+     * Autor: Huluvu424242
+     * Lizenz: MIT
+     * Quelle: selbst erstellt
+     */
+    help: `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M9.4 9.2a2.6 2.6 0 0 1 5.2.1c0 1.2-.7 1.8-1.8 2.5-.8.5-1.3 1-1.3 2" />
+        <circle cx="12" cy="16.9" r="0.7" />
+    </svg>
+  `,
+    /*
      * Icon: speaking_head
      * Autor: Twitter
      * Lizenz: MIT
@@ -304,4 +317,3 @@ export function toggleIconState(element) {
     setIconState(element, iconStateGroup, nextState);
     return nextState;
 }
-

--- a/src/layout.js
+++ b/src/layout.js
@@ -17,6 +17,8 @@ const ELEMENT_SELECTORS = {
     transcriptText: '#transcript-text',
     transcriptAudioPlayer: '#transcript-audio-player',
     autoplayNextCheckbox: '#autoplay-next-checkbox',
+    helpToggleBtn: '#help-toggle-btn',
+    helpPanel: '#help-panel',
     remoteUrlInput: '#remote-url-input',
     zipInput: '#zip-input',
     pickDirectoryBtn: '#pick-directory-btn',

--- a/src/styles.css
+++ b/src/styles.css
@@ -385,6 +385,39 @@ input[type="url"] {
     padding-left: 6px;
 }
 
+.icon-btn--help {
+    width: 34px;
+    height: 34px;
+}
+
+.icon-btn--help .icon {
+    width: 18px;
+    height: 18px;
+}
+
+.help-panel {
+    margin: 12px 18px 0;
+    padding: 12px 14px;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: rgba(35, 42, 52, 0.55);
+}
+
+.help-panel h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.help-panel p {
+    margin: 10px 0 0;
+}
+
+.help-panel ul {
+    margin: 8px 0 0;
+    padding-left: 22px;
+    line-height: 1.45;
+}
+
 @media (max-width: 1100px) {
     .app-shell {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Provide an inline, discoverable help affordance next to the "Nächste Folie automatisch" control that explains all slide navigation, click and touch controls. 

### Description
- Add a compact question-mark help button to the toolbar in `index.html` (`#help-toggle-btn`) and a toggleable help panel (`#help-panel`) with the control documentation. 
- Wire the UI in `src/app.js` by registering a click handler and adding `isHelpPanelOpen`/`toggleHelpPanel` functions that update `aria-expanded` and the button tooltip. 
- Register new selectors in `src/layout.js` and add a new `help` SVG icon in `src/icons.js`. 
- Add styling for the help button and the help panel in `src/styles.css`. 

### Testing
- Performed syntax checks with `node --check` on `src/app.js`, `src/layout.js` and `src/icons.js`, which completed successfully. 
- Verified repository state with `git status --short` and committed the changes (no failing automated checks reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68670bce0832aaea30009ff8b560e)