### PR TITLE
Extract help panel toggle into src/hilfe.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,7 @@ import {
     updateTranscriptToggleButton,
 } from './layout.js';
 import {showError, withErrorHandling} from './error.js';
+import {toggleHelpPanel} from './hilfe.js';
 
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const DEFAULT_SLIDE_SHOWTIME_SECONDS = 10;
@@ -185,7 +186,7 @@ function bindEvents() {
     });
     elements.helpToggleBtn.addEventListener('click', (event) => {
         event.preventDefault();
-        toggleHelpPanel();
+        toggleHelpPanel(elements.helpPanel, elements.helpToggleBtn);
     });
     elements.transcriptToggleBtn.addEventListener('click', async (event) => {
         event.preventDefault();
@@ -1009,20 +1010,6 @@ function setTranscriptPanelVisibility(isVisible) {
     elements.transcriptPanel.classList.toggle('hidden', !isVisible);
     updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
 }
-
-function isHelpPanelOpen() {
-    return !elements.helpPanel.classList.contains('hidden');
-}
-
-function toggleHelpPanel() {
-    const shouldOpen = !isHelpPanelOpen();
-    elements.helpPanel.classList.toggle('hidden', !shouldOpen);
-    elements.helpToggleBtn.setAttribute('aria-expanded', String(shouldOpen));
-    const tooltipText = shouldOpen ? 'Steuerungshilfe ausblenden' : 'Steuerungshilfe anzeigen';
-    elements.helpToggleBtn.title = tooltipText;
-    elements.helpToggleBtn.setAttribute('aria-label', tooltipText);
-}
-
 function hideTranscriptPanel() {
     setTranscriptPanelVisibility(false);
     clearTranscriptPanelContent();

--- a/src/hilfe.js
+++ b/src/hilfe.js
@@ -1,0 +1,12 @@
+export function isHelpPanelOpen(helpPanelElement) {
+    return !helpPanelElement.classList.contains('hidden');
+}
+
+export function toggleHelpPanel(helpPanelElement, helpToggleButtonElement) {
+    const shouldOpen = !isHelpPanelOpen(helpPanelElement);
+    helpPanelElement.classList.toggle('hidden', !shouldOpen);
+    helpToggleButtonElement.setAttribute('aria-expanded', String(shouldOpen));
+    const tooltipText = shouldOpen ? 'Steuerungshilfe ausblenden' : 'Steuerungshilfe anzeigen';
+    helpToggleButtonElement.title = tooltipText;
+    helpToggleButtonElement.setAttribute('aria-label', tooltipText);
+}


### PR DESCRIPTION
### Motivation
- Separate the help-panel visibility logic from `src/app.js` to improve modularity and keep UI event wiring and panel behavior decoupled.

### Description
- Added `src/hilfe.js` exporting `isHelpPanelOpen` and `toggleHelpPanel`, updated `src/app.js` to `import {toggleHelpPanel} from './hilfe.js'`, call `toggleHelpPanel(elements.helpPanel, elements.helpToggleBtn)` from the help button handler, and removed the local help functions from `src/app.js`.

### Testing
- Ran `node --check src/app.js` and `node --check src/hilfe.js`, both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68b2cc634832aadf917289a0b7ef1)