### PR TITLE
Extract player controls and auto-advance logic into new player module

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,6 +35,12 @@ import {
 } from './layout.js';
 import {showError, withErrorHandling} from './error.js';
 import {toggleHelpPanel} from './hilfe.js';
+import {
+    bindAutoAdvanceToggle,
+    bindPlayerButtonEvents,
+    scheduleAutoAdvanceForShowtime as scheduleAutoAdvanceForShowtimeInPlayer,
+    syncAutoSlideChangeForCurrentSlide as syncAutoSlideChangeForCurrentSlideInPlayer,
+} from './player.js';
 
 const SLIDE_CHANGE_BELL_PAUSE_SECONDS = 0.7;
 const DEFAULT_SLIDE_SHOWTIME_SECONDS = 10;
@@ -146,43 +152,26 @@ function bindEvents() {
         });
     });
 
-    elements.firstBtn.addEventListener('click', () => goToSlide(0));
-    elements.prevBtn.addEventListener('click', () => goToSlide(state.currentIndex - 1));
-    elements.nextBtn.addEventListener('click', () => goToSlide(state.currentIndex + 1));
-    elements.lastBtn.addEventListener('click', () => goToSlide(state.deck?.slides.length - 1 ?? -1));
-    elements.gotoBtn.addEventListener('click', () => goToSlide(Number(elements.gotoInput.value) - 1));
-    elements.playBtn.addEventListener('click', async (event) => {
-        event.preventDefault();
-        if (!state.deck || state.currentIndex < 0) {
-            return;
-        }
-
-        if (elements.audioStatus.textContent === 'Pausiert') {
-            await resumePresentation();
-            keepPlaybackButtonFocus();
-            return;
-        }
-
-        await withErrorHandling(elements.errorBox, async () => {
-            await playCurrentSlide();
-        });
-        keepPlaybackButtonFocus();
+    bindPlayerButtonEvents({
+        elements,
+        getCurrentIndex: () => state.currentIndex,
+        getDeck: () => state.deck,
+        getAudioStatus: () => elements.audioStatus.textContent,
+        goToSlide,
+        resumePresentation,
+        playCurrentSlide,
+        pausePresentation,
+        stopPresentation,
+        keepPlaybackButtonFocus,
+        withErrorHandling,
+        errorBox: elements.errorBox,
     });
-    elements.pauseBtn.addEventListener('click', async () => {
-        await pausePresentation();
-    });
-    elements.stopBtn.addEventListener('click', async () => {
-        clearSlideAdvanceTimer();
-        clearShowtimeCountdown();
-        nonAudioPlaybackRemainingSeconds = null;
-        pausedNonAudioRemainingSeconds = null;
-        hasPresentationStarted = false;
-        setPlayButtonActive(false);
-        await audioController.stop();
-    });
-    elements.autoplayNextCheckbox.addEventListener('change', () => {
-        state.autoAdvance = elements.autoplayNextCheckbox.checked;
-        syncAutoSlideChangeForCurrentSlide();
+    bindAutoAdvanceToggle({
+        elements,
+        setAutoAdvanceEnabled(value) {
+            state.autoAdvance = value;
+        },
+        syncAutoSlideChangeForCurrentSlide,
     });
     elements.helpToggleBtn.addEventListener('click', (event) => {
         event.preventDefault();
@@ -522,46 +511,34 @@ function updateSlideAudioStatus(slide) {
     elements.audioStatus.textContent = `Kein Audio – Anzeige ${showtime} s`;
 }
 
-function scheduleAutoAdvanceForShowtime(slide) {
-    clearSlideAdvanceTimer();
-
-    const showtime = getSlideShowtimeSeconds(slide);
-    if (!state.autoAdvance) {
-        updateSlideAudioStatus(slide);
-        return false;
-    }
-
-    updateSlideAudioStatus(slide);
-    slideAdvanceTimer = window.setTimeout(async () => {
-        slideAdvanceTimer = null;
-        if (!state.autoAdvance || !state.deck) {
-            return;
-        }
-        await handleSlidePlaybackCompleted();
-    }, showtime * 1000);
-
-    return true;
-}
-
 function syncAutoSlideChangeForCurrentSlide() {
     const slide = state.deck?.slides[state.currentIndex];
-    if (!slide || slide.audio) {
-        nonAudioPlaybackRemainingSeconds = null;
-        clearSlideAdvanceTimer();
-        clearShowtimeCountdown();
-        setPlayButtonActive(false);
-        return;
-    }
+    syncAutoSlideChangeForCurrentSlideInPlayer({
+        slide,
+        autoAdvance: state.autoAdvance,
+        setNonAudioPlaybackRemainingSeconds(value) {
+            nonAudioPlaybackRemainingSeconds = value;
+        },
+        clearSlideAdvanceTimer,
+        clearShowtimeCountdown,
+        setPlayButtonActive,
+        startShowtimeCountdown,
+        scheduleAutoAdvanceForShowtime,
+    });
+}
 
-    if (!state.autoAdvance) {
-        clearSlideAdvanceTimer();
-        setPlayButtonActive(false);
-        return;
-    }
-
-    setPlayButtonActive(true);
-    startShowtimeCountdown(slide);
-    scheduleAutoAdvanceForShowtime(slide);
+function scheduleAutoAdvanceForShowtime(slide) {
+    return scheduleAutoAdvanceForShowtimeInPlayer({
+        slide,
+        autoAdvance: () => state.autoAdvance && Boolean(state.deck),
+        clearSlideAdvanceTimer,
+        updateSlideAudioStatus,
+        getSlideShowtimeSeconds,
+        setSlideAdvanceTimer(timerId) {
+            slideAdvanceTimer = timerId;
+        },
+        onPlaybackCompleted: handleSlidePlaybackCompleted,
+    });
 }
 
 async function handleSlidePlaybackCompleted() {
@@ -923,6 +900,16 @@ async function resumePresentation() {
     }
 
     await audioController.resume();
+}
+
+async function stopPresentation() {
+    clearSlideAdvanceTimer();
+    clearShowtimeCountdown();
+    nonAudioPlaybackRemainingSeconds = null;
+    pausedNonAudioRemainingSeconds = null;
+    hasPresentationStarted = false;
+    setPlayButtonActive(false);
+    await audioController.stop();
 }
 
 async function showTranscriptPanelBySwipe() {

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,115 @@
+export function bindPlayerButtonEvents({
+    elements,
+    getCurrentIndex,
+    getDeck,
+    getAudioStatus,
+    goToSlide,
+    resumePresentation,
+    playCurrentSlide,
+    pausePresentation,
+    stopPresentation,
+    keepPlaybackButtonFocus,
+    withErrorHandling,
+    errorBox,
+}) {
+    elements.firstBtn.addEventListener('click', () => goToSlide(0));
+    elements.prevBtn.addEventListener('click', () => goToSlide(getCurrentIndex() - 1));
+    elements.nextBtn.addEventListener('click', () => goToSlide(getCurrentIndex() + 1));
+    elements.lastBtn.addEventListener('click', () => goToSlide(getDeck()?.slides.length - 1 ?? -1));
+    elements.gotoBtn.addEventListener('click', () => goToSlide(Number(elements.gotoInput.value) - 1));
+
+    elements.playBtn.addEventListener('click', async (event) => {
+        event.preventDefault();
+        if (!getDeck() || getCurrentIndex() < 0) {
+            return;
+        }
+
+        if (getAudioStatus() === 'Pausiert') {
+            await resumePresentation();
+            keepPlaybackButtonFocus();
+            return;
+        }
+
+        await withErrorHandling(errorBox, async () => {
+            await playCurrentSlide();
+        });
+        keepPlaybackButtonFocus();
+    });
+
+    elements.pauseBtn.addEventListener('click', async () => {
+        await pausePresentation();
+    });
+
+    elements.stopBtn.addEventListener('click', async () => {
+        await stopPresentation();
+    });
+}
+
+export function bindAutoAdvanceToggle({
+    elements,
+    setAutoAdvanceEnabled,
+    syncAutoSlideChangeForCurrentSlide,
+}) {
+    elements.autoplayNextCheckbox.addEventListener('change', () => {
+        setAutoAdvanceEnabled(elements.autoplayNextCheckbox.checked);
+        syncAutoSlideChangeForCurrentSlide();
+    });
+}
+
+export function scheduleAutoAdvanceForShowtime({
+    slide,
+    autoAdvance,
+    clearSlideAdvanceTimer,
+    updateSlideAudioStatus,
+    getSlideShowtimeSeconds,
+    setSlideAdvanceTimer,
+    onPlaybackCompleted,
+}) {
+    clearSlideAdvanceTimer();
+
+    const showtime = getSlideShowtimeSeconds(slide);
+    if (!autoAdvance()) {
+        updateSlideAudioStatus(slide);
+        return false;
+    }
+
+    updateSlideAudioStatus(slide);
+    setSlideAdvanceTimer(window.setTimeout(async () => {
+        setSlideAdvanceTimer(null);
+        if (!autoAdvance()) {
+            return;
+        }
+        await onPlaybackCompleted();
+    }, showtime * 1000));
+
+    return true;
+}
+
+export function syncAutoSlideChangeForCurrentSlide({
+    slide,
+    autoAdvance,
+    setNonAudioPlaybackRemainingSeconds,
+    clearSlideAdvanceTimer,
+    clearShowtimeCountdown,
+    setPlayButtonActive,
+    startShowtimeCountdown,
+    scheduleAutoAdvanceForShowtime,
+}) {
+    if (!slide || slide.audio) {
+        setNonAudioPlaybackRemainingSeconds(null);
+        clearSlideAdvanceTimer();
+        clearShowtimeCountdown();
+        setPlayButtonActive(false);
+        return;
+    }
+
+    if (!autoAdvance) {
+        clearSlideAdvanceTimer();
+        setPlayButtonActive(false);
+        return;
+    }
+
+    setPlayButtonActive(true);
+    startShowtimeCountdown(slide);
+    scheduleAutoAdvanceForShowtime(slide);
+}


### PR DESCRIPTION
### Motivation
- Reduce `app.js` surface area and improve modularity by moving playback UI handlers and auto-advance logic into a focused `player` module for easier testing and maintenance.

### Description
- Add `src/player.js` which exports `bindPlayerButtonEvents`, `bindAutoAdvanceToggle`, `scheduleAutoAdvanceForShowtime`, and `syncAutoSlideChangeForCurrentSlide` and encapsulates player-related event wiring and auto-advance scheduling logic.
- Replace inline playback event listeners in `src/app.js` with `bindPlayerButtonEvents` and `bindAutoAdvanceToggle` imports and calls, and delegate auto-advance coordination to the new module via `scheduleAutoAdvanceForShowtimeInPlayer` and `syncAutoSlideChangeForCurrentSlideInPlayer` wrappers.
- Reintroduce a `stopPresentation` helper in `src/app.js` to centralize stop behavior previously inlined into the removed click handler.

### Testing
- Ran the project test suite with `npm test`, which completed successfully.
- Built the application with `npm run build`, and the build succeeded.
- Ran lint checks with `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68c44b31c832abee96172e707a60a)