### PR TITLE
Fix top scroll behavior to prevent toolbar overlap on desktop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -376,7 +376,7 @@ function clearSingleClickActionTimer() {
 }
 
 function scrollToSlideStageTop() {
-    elements.slideStage?.scrollIntoView({behavior: 'auto', block: 'start'});
+    window.scrollTo({top: 0, left: 0, behavior: 'auto'});
 }
 
 function clearSlideAdvanceTimer() {


### PR DESCRIPTION
### Motivation
- Desktop view showed the top of the presentation/help content hidden under the sticky player toolbar after startup or slide changes, because `#slide-stage` was aligned with `scrollIntoView` rather than the page top. 
- The intent is to ensure the viewport always appears fully scrolled to the top so the toolbar no longer covers content after navigation or panel toggles.

### Description
- Replaced the `scrollToSlideStageTop()` implementation to call `window.scrollTo({ top: 0, left: 0, behavior: 'auto' })` instead of `elements.slideStage?.scrollIntoView(...)` in `src/app.js`.
- This central helper is used by startup, slide-change and transcript/help close flows, so the change applies across those existing call sites without modifying each caller.

### Testing
- Ran `node --check src/app.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68f704af0832a94582dd2c3ea6323)