### PR TITLE
Adaptive scroll/centering and swipe-up transcript toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
             <li><strong>Tastatur:</strong> ← / → für vorherige bzw. nächste Folie, Home für erste, Ende für letzte Folie, Leertaste startet die aktuelle Folie.</li>
             <li><strong>Klick im Folienbereich:</strong> Einfachklick startet/pausiert die Präsentation.</li>
             <li><strong>Doppelklick im Folienbereich:</strong> Scrollt zurück an den Anfang der Folie.</li>
-            <li><strong>Touch-Gesten:</strong> Wischen links/rechts wechselt Folien, Wischen nach oben/unten zeigt/versteckt den Audiotext, Tippen startet/pausiert.</li>
+            <li><strong>Touch-Gesten:</strong> Wischen links/rechts wechselt Folien, Wischen nach oben blendet den Audiotext ein bzw. aus, Tippen startet/pausiert.</li>
             <li><strong>Gehe zu:</strong> Foliennummer eingeben und mit <em>Los</em> direkt springen.</li>
           </ul>
         </section>

--- a/src/app.js
+++ b/src/app.js
@@ -208,6 +208,10 @@ function bindEvents() {
     registerStageInteractionArea(elements.slideStage);
     registerStageInteractionArea(elements.transcriptPanel);
     registerStageInteractionArea(elements.errorBox);
+
+    window.addEventListener('resize', () => {
+        centerSlideStageHorizontally();
+    });
 }
 
 function registerStageInteractionArea(element) {
@@ -284,11 +288,7 @@ async function handleTouchEnd(event) {
     }
 
     if (isVerticalSwipe) {
-        if (verticalDistance < 0) {
-            await showTranscriptPanelBySwipe();
-            return;
-        }
-        await hideTranscriptPanelBySwipe();
+        await toggleTranscriptPanelBySwipe(verticalDistance);
         return;
     }
 
@@ -376,7 +376,54 @@ function clearSingleClickActionTimer() {
 }
 
 function scrollToSlideStageTop() {
-    window.scrollTo({top: 0, left: 0, behavior: 'auto'});
+    const top = shouldScrollToDocumentTop()
+        ? 0
+        : window.scrollY + elements.slideStage.getBoundingClientRect().top;
+    window.scrollTo({top, left: 0, behavior: 'auto'});
+    centerSlideStageHorizontally();
+}
+
+function shouldScrollToDocumentTop() {
+    if (hasStackedSidebarAboveStage()) {
+        return false;
+    }
+    return !hasVisibleContentBeforeSlideStage();
+}
+
+function hasStackedSidebarAboveStage() {
+    const stageRoot = elements.slideStage.closest('.stage');
+    if (!stageRoot) {
+        return false;
+    }
+    return stageRoot.getBoundingClientRect().top > 1;
+}
+
+function hasVisibleContentBeforeSlideStage() {
+    const stageRoot = elements.slideStage.closest('.stage');
+    if (!stageRoot) {
+        return false;
+    }
+
+    for (const child of stageRoot.children) {
+        if (child === elements.slideStage) {
+            break;
+        }
+        if (child === elements.playerToolbar) {
+            continue;
+        }
+        if (child.classList.contains('hidden')) {
+            continue;
+        }
+        if (child.getBoundingClientRect().height > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function centerSlideStageHorizontally() {
+    const horizontalOverflow = elements.slideStage.scrollWidth - elements.slideStage.clientWidth;
+    elements.slideStage.scrollLeft = Math.max(0, horizontalOverflow / 2);
 }
 
 function clearSlideAdvanceTimer() {
@@ -739,6 +786,7 @@ async function renderCurrentSlide() {
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
         elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
+        centerSlideStageHorizontally();
         if (elements.showtimeCountdown) {
             renderShowtimeDash();
         }
@@ -760,6 +808,7 @@ async function renderCurrentSlide() {
       ${html}
     </article>
   `;
+    centerSlideStageHorizontally();
 
     await hydrateAsyncAssets();
 
@@ -924,6 +973,17 @@ async function hideTranscriptPanelBySwipe() {
         return;
     }
     setTranscriptPanelVisibility(false);
+}
+
+async function toggleTranscriptPanelBySwipe(verticalDistance) {
+    if (verticalDistance >= 0) {
+        return;
+    }
+    if (isTranscriptPanelOpen()) {
+        await hideTranscriptPanelBySwipe();
+        return;
+    }
+    await showTranscriptPanelBySwipe();
 }
 
 function renderSlideList() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -333,6 +333,7 @@ input[type="url"] {
 
 .slide-card {
     width: min(1200px, 100%);
+    margin-inline: auto;
     min-height: calc(100vh - 120px);
     background: linear-gradient(180deg, #f6f8fb, #e9eef6);
     color: #111827;
@@ -369,6 +370,7 @@ input[type="url"] {
 
 .placeholder {
     width: min(920px, 100%);
+    margin-inline: auto;
     min-height: calc(100vh - 120px);
     border: 2px dashed var(--border);
     border-radius: 28px;


### PR DESCRIPTION
### Motivation
- Auf mobilen/gestapelten Layouts soll `scrollToSlideStageTop` das Scrollziel an die jeweilige Anordnung anpassen, damit Fehler/Hilfetexte oder die Slide-Liste nicht überdeckt werden.
- Die Präsentation soll horizontal zentriert bleiben, damit Inhalte auch auf schmalen Bildschirmen gut lesbar sind.
- Die Swipe-Logik soll vereinfacht werden: ein Swipe von unten nach oben toggelt den Audiotext, das Swipen von oben entfällt.

### Description
- `scrollToSlideStageTop` wurde so geändert, dass es per `shouldScrollToDocumentTop()` entscheidet, ob auf `top: 0` gescrollt wird oder nur bis zum Beginn von `elements.slideStage`, und ruft danach `centerSlideStageHorizontally()` auf; die neue Hilfsfunktionen sind `hasStackedSidebarAboveStage()` und `hasVisibleContentBeforeSlideStage()` (in `src/app.js`).
- Horizontale Zentrierung wurde ergänzt durch `centerSlideStageHorizontally()` und Aufrufe davon nach Slide-Render, beim Placeholder-Render und im `resize`-Event (in `src/app.js`).
- Vertikales Swipe-Verhalten wurde zu einem einzelnen Up-Swipe-Toggle umgesetzt: `handleTouchEnd` verwendet jetzt `toggleTranscriptPanelBySwipe(verticalDistance)`, und die neuen Funktionen `toggleTranscriptPanelBySwipe`, `showTranscriptPanelBySwipe` und `hideTranscriptPanelBySwipe` steuern das Öffnen/Schließen des Transcript-Panels (in `src/app.js`).
- Hilfe-Text in `index.html` wurde aktualisiert, um das neue Gestenverhalten widerzuspiegeln.
- CSS in `src/styles.css` wurde erweitert (`margin-inline: auto` für `.slide-card` und `.placeholder`), um die horizontale Zentrierung via Layout zu unterstützen.

### Testing
- Automatische Syntax-Checks wurden ausgeführt mit `node --check src/app.js` und `node --check src/swipe.js`, und beide Prüfungen sind erfolgreich durchgelaufen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6924d4a94832aa9d14371b44838d8)