### PR TITLE
Audiotext bevorzugen: Audioplayer nur für echte Audiodateien im Transcript-Panel

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1089,20 +1089,6 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     }
 
     const audioType = inferAudioType(slide.audio);
-    elements.transcriptAudioPlayer.classList.remove('hidden');
-
-    try {
-        const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
-        elements.transcriptAudioPlayer.src = resolvedSource;
-        const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
-        elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
-        if (!playableInBrowser) {
-            elements.transcriptAudioPlayer.pause();
-        }
-    } catch (error) {
-        elements.transcriptAudioPlayer.classList.add('is-disabled');
-        elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
-    }
 
     if (isTextAudioType(audioType)) {
         try {
@@ -1122,6 +1108,19 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     }
 
     if (isPlayableAudioType(audioType, slide.audio.src)) {
+        elements.transcriptAudioPlayer.classList.remove('hidden');
+        try {
+            const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+            elements.transcriptAudioPlayer.src = resolvedSource;
+            const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
+            elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
+            if (!playableInBrowser) {
+                elements.transcriptAudioPlayer.pause();
+            }
+        } catch (error) {
+            elements.transcriptAudioPlayer.classList.add('is-disabled');
+            elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
+        }
         if (!elements.transcriptHint.textContent) {
             elements.transcriptHint.textContent = 'Für diese Folie liegt eine Audio-Datei vor. Du kannst im Player navigieren.';
         }


### PR DESCRIPTION
### Motivation

- Das Transcript-Panel soll bei vorhandenen Text-Audioquellen (`.txt`/`.ssml`) den Text für TTS anzeigen und nicht gleichzeitig den Audioplayer zeigen.
- Falls kein Audiotext vorhanden ist, aber eine echte abspielbare Audiodatei vorliegt, soll der Audioplayer geladen und sichtbar sein, damit Nutzer die Datei abspielen können.

### Description

- In `src/app.js` wurde die Initialisierung des eingebetteten Audioplayers aus dem allgemeinen Pfad entfernt und stattdessen nur noch innerhalb des `isPlayableAudioType`-Zweigs aufgerufen, sodass `isTextAudioType`-Quellen ausschließlich als Text angezeigt werden (`renderTranscriptContent` wurde angepasst). 
- Die Textlade-/Anzeige-Logik für `txt`/`ssml`-Quellen wurde unverändert beibehalten und sorgt dafür, dass bei Erfolg der Text sichtbar wird und der Player ausgeblendet bleibt.
- Die Player-Initialisierung, Playability-Prüfung und Fehlerbehandlung für reale Audio-Dateien (z. B. `mp3`, `wav`, `ogg`) wurden in den `isPlayableAudioType`-Block verlegt, sodass der Player nur dann eingeblendet und mit `state.deck.assetLoader.resolvePlayableUrl` geladen wird.
- Das Zurücksetzen des Transcript-Panels (`clearTranscriptPanelContent`) bleibt erhalten und stellt sicher, dass zuvor gesetzte Texte/Player-Attribute entfernt werden.

### Testing

- `node --check src/app.js` wurde ausgeführt und hat ohne Fehler abgeschlossen.
- Es wurden keine zusätzlichen automatisierten Tests im Repository ausgeführt; manuelle Laufzeitverifikation empfohlen, insbesondere das Öffnen des Transcript-Panels mit verschiedenen `audio`-Quellen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69730d650832ab4848666092763a7)