### PR TITLE
Only show audio player for playable audio types and centralize playable type list

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1089,20 +1089,6 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     }
 
     const audioType = inferAudioType(slide.audio);
-    elements.transcriptAudioPlayer.classList.remove('hidden');
-
-    try {
-        const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
-        elements.transcriptAudioPlayer.src = resolvedSource;
-        const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
-        elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
-        if (!playableInBrowser) {
-            elements.transcriptAudioPlayer.pause();
-        }
-    } catch (error) {
-        elements.transcriptAudioPlayer.classList.add('is-disabled');
-        elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
-    }
 
     if (isTextAudioType(audioType)) {
         try {
@@ -1122,6 +1108,19 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     }
 
     if (isPlayableAudioType(audioType, slide.audio.src)) {
+        elements.transcriptAudioPlayer.classList.remove('hidden');
+        try {
+            const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+            elements.transcriptAudioPlayer.src = resolvedSource;
+            const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
+            elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
+            if (!playableInBrowser) {
+                elements.transcriptAudioPlayer.pause();
+            }
+        } catch (error) {
+            elements.transcriptAudioPlayer.classList.add('is-disabled');
+            elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
+        }
         if (!elements.transcriptHint.textContent) {
             elements.transcriptHint.textContent = 'Für diese Folie liegt eine Audio-Datei vor. Du kannst im Player navigieren.';
         }

--- a/src/transcript.js
+++ b/src/transcript.js
@@ -37,8 +37,12 @@ export function isTextAudioType(audioType) {
 }
 
 export function isPlayableAudioType(audioType, sourcePath = '') {
-    if (audioType && !isTextAudioType(audioType)) {
+    const normalizedType = String(audioType || '').toLowerCase();
+    if (PLAYABLE_AUDIO_TYPES.has(normalizedType)) {
         return true;
+    }
+    if (normalizedType && !isTextAudioType(normalizedType)) {
+        return false;
     }
 
     const extension = String(sourcePath)
@@ -48,8 +52,10 @@ export function isPlayableAudioType(audioType, sourcePath = '') {
         .pop()
         ?.toLowerCase();
 
-    return ['mp3', 'm4a', 'aac', 'wav', 'ogg', 'oga', 'opus', 'flac', 'webm', 'mp4'].includes(extension || '');
+    return PLAYABLE_AUDIO_TYPES.has(extension || '');
 }
+
+const PLAYABLE_AUDIO_TYPES = new Set(['mp3', 'm4a', 'aac', 'wav', 'ogg', 'oga', 'opus', 'flac', 'webm', 'mp4']);
 
 export function preserveStructuredText(text) {
     return String(text)


### PR DESCRIPTION
### Motivation
- Prevent displaying a disabled audio player for audio entries that are text-based or unsupported by the browser and make playable-type detection more robust.

### Description
- Move showing the transcript audio player into the playable-audio branch so the player is only revealed for actual playable audio files.
- Refactor `isPlayableAudioType` to normalize input and use a centralized `PLAYABLE_AUDIO_TYPES` set for extension/type checks.
- Use the normalized audio type to short-circuit decisions and fallback to checking the source file extension when type is empty.
- Add the `PLAYABLE_AUDIO_TYPES` constant and simplify extension membership checks to improve maintainability.

### Testing
- Ran the project's linting and unit tests via `npm run lint` and `npm test`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69730d650832ab4848666092763a7)