### PR TITLE
Fix transcript audio player visibility race

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,6 +64,7 @@ let hasPresentationStarted = false;
 let singleTouchActionTimer = null;
 let singleClickActionTimer = null;
 let lastTouchTapTimestamp = 0;
+let transcriptRenderToken = 0;
 
 await initApp();
 
@@ -972,6 +973,7 @@ async function hideTranscriptPanelBySwipe() {
     if (!isTranscriptPanelOpen()) {
         return;
     }
+    transcriptRenderToken += 1;
     setTranscriptPanelVisibility(false);
 }
 
@@ -1058,6 +1060,7 @@ function setTranscriptPanelVisibility(isVisible) {
     updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
 }
 function hideTranscriptPanel() {
+    transcriptRenderToken += 1;
     setTranscriptPanelVisibility(false);
     clearTranscriptPanelContent();
     scrollToSlideStageTop();
@@ -1079,6 +1082,7 @@ function isTranscriptPanelOpen() {
 }
 
 async function renderTranscriptContent({keepOpen = false} = {}) {
+    const renderToken = ++transcriptRenderToken;
     const slide = state.deck?.slides[state.currentIndex];
     clearTranscriptPanelContent();
 
@@ -1093,6 +1097,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     if (isTextAudioType(audioType)) {
         try {
             const textContent = await state.deck.assetLoader.loadText(slide.audio.src);
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptText.textContent = audioType === 'ssml'
                 ? ssmlToDisplayText(textContent)
                 : preserveStructuredText(textContent);
@@ -1101,6 +1108,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
                 elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
             }
         } catch (error) {
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptHint.textContent = 'Der Text zur Audio-Datei konnte nicht geladen werden.';
         }
         setTranscriptPanelVisibility(keepOpen);
@@ -1111,6 +1121,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
         elements.transcriptAudioPlayer.classList.remove('hidden');
         try {
             const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptAudioPlayer.src = resolvedSource;
             const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
             elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
@@ -1118,6 +1131,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
                 elements.transcriptAudioPlayer.pause();
             }
         } catch (error) {
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptAudioPlayer.classList.add('is-disabled');
             elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
         }


### PR DESCRIPTION
### Motivation

- Behebt ein Problem, bei dem der Audioplayer im Transcript nach Folienwechsel sichtbar bleiben konnte, weil asynchrone Lade-Pfade veraltet abgeschlossen wurden.
- Ziel ist, die Ein-/Ausblende-Logik des Transkript-Panels robuster gegen out-of-order async-Abschlüsse zu machen.

### Description

- In `src/app.js` wurde ein `transcriptRenderToken` hinzugefügt, um laufende asynchrone Render-Läufe zu invalidieren.
- Asynchrone Pfade in `renderTranscriptContent` prüfen nun vor dem Mutieren der UI, ob der Renderlauf noch aktuell ist, und brechen sonst ab.
- Beim Schließen des Transkript-Panels (normal und per Swipe) wird `transcriptRenderToken` erhöht, um ausstehende Renderläufe zu invalidieren.

### Testing

- `node --check src/app.js` wurde ausgeführt und meldet keine Syntaxfehler (Erfolg). 
- Ein Versuch, die Remote-`slides.json` per `curl` abzurufen, schlug in dieser Umgebung mit `403`/Tunnel-Fehler fehl, daher konnte kein Live-Integrationstest gegen diese URL ausgeführt werden (Umgebungsfehler).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69bf6ed00832a900f3dcb913323bc)