### PR TITLE
Avoid transcript rendering races and properly hide transcript audio player

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,6 +64,7 @@ let hasPresentationStarted = false;
 let singleTouchActionTimer = null;
 let singleClickActionTimer = null;
 let lastTouchTapTimestamp = 0;
+let transcriptRenderToken = 0;
 
 await initApp();
 
@@ -972,6 +973,7 @@ async function hideTranscriptPanelBySwipe() {
     if (!isTranscriptPanelOpen()) {
         return;
     }
+    transcriptRenderToken += 1;
     setTranscriptPanelVisibility(false);
 }
 
@@ -1058,6 +1060,7 @@ function setTranscriptPanelVisibility(isVisible) {
     updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
 }
 function hideTranscriptPanel() {
+    transcriptRenderToken += 1;
     setTranscriptPanelVisibility(false);
     clearTranscriptPanelContent();
     scrollToSlideStageTop();
@@ -1079,6 +1082,7 @@ function isTranscriptPanelOpen() {
 }
 
 async function renderTranscriptContent({keepOpen = false} = {}) {
+    const renderToken = ++transcriptRenderToken;
     const slide = state.deck?.slides[state.currentIndex];
     clearTranscriptPanelContent();
 
@@ -1093,6 +1097,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
     if (isTextAudioType(audioType)) {
         try {
             const textContent = await state.deck.assetLoader.loadText(slide.audio.src);
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptText.textContent = audioType === 'ssml'
                 ? ssmlToDisplayText(textContent)
                 : preserveStructuredText(textContent);
@@ -1101,6 +1108,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
                 elements.transcriptHint.textContent = 'Text aus der in slides.json referenzierten Audio-Datei.';
             }
         } catch (error) {
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptHint.textContent = 'Der Text zur Audio-Datei konnte nicht geladen werden.';
         }
         setTranscriptPanelVisibility(keepOpen);
@@ -1111,6 +1121,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
         elements.transcriptAudioPlayer.classList.remove('hidden');
         try {
             const resolvedSource = await state.deck.assetLoader.resolvePlayableUrl(slide.audio.src);
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptAudioPlayer.src = resolvedSource;
             const playableInBrowser = canPlayInAudioElement(elements.transcriptAudioPlayer, audioType, slide.audio.src);
             elements.transcriptAudioPlayer.classList.toggle('is-disabled', !playableInBrowser);
@@ -1118,6 +1131,9 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
                 elements.transcriptAudioPlayer.pause();
             }
         } catch (error) {
+            if (renderToken !== transcriptRenderToken) {
+                return;
+            }
             elements.transcriptAudioPlayer.classList.add('is-disabled');
             elements.transcriptHint.textContent = 'Die Audioquelle konnte nicht in den Player geladen werden.';
         }

--- a/src/styles.css
+++ b/src/styles.css
@@ -100,6 +100,10 @@ code {
     width: min(540px, 100%);
 }
 
+#transcript-audio-player.hidden {
+    display: none;
+}
+
 #transcript-audio-player.is-disabled {
     opacity: 0.45;
     filter: grayscale(1);


### PR DESCRIPTION
### Motivation
- Prevent visual glitches and stale content when opening/closing the transcript panel while async asset loading is in progress.

### Description
- Introduce a `transcriptRenderToken` counter and use it to cancel outdated async `renderTranscriptContent` work by early-returning when the token has changed.
- Increment the token when the transcript panel is hidden via swipe or programmatic `hideTranscriptPanel` to ensure in-flight renders are ignored.
- Add a CSS rule `#transcript-audio-player.hidden { display: none; }` so the transcript audio element can be fully hidden via the existing `.hidden` class.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69bf6ed00832a900f3dcb913323bc)