### PR TITLE
GUI-Reihenfolge umgebaut und Countdown von Zahl auf Fortschrittslinie umgestellt

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,44 +19,10 @@
     <div class="app-shell">
       <main class="stage">
       <h1>Slideshow Viewer</h1>
-      <div class="project-intro">
-        <p class="project-links">
-          Quellen:
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer" target="_blank" rel="noreferrer">
-                    sld-slideshow-viewer
-                </a>,
-                <a href="https://huluvu424242.github.io/foile-pile/" target="_blank" rel="noreferrer">
-                    Präsentationen (Sammlung)
-                </a>
-        </p>
-        <p class="project-links">
-          Dokumentation:
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/README.md" target="_blank"
-                   rel="noreferrer">Doku-Index</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/README.md" target="_blank"
-                   rel="noreferrer">README</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/createslideshow.md"
-                   target="_blank" rel="noreferrer">Create Slideshow</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/architecture.md"
-                   target="_blank" rel="noreferrer">Architektur</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/manifest.md" target="_blank"
-                   rel="noreferrer">Manifest</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/sld-spec.md" target="_blank"
-                   rel="noreferrer">SLD-Spec</a>,
-                <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/roadmap.md" target="_blank"
-                   rel="noreferrer">Roadmap</a>
-        </p>
-      </div>
-
         <div id="error-box" class="error-box hidden" role="alert"></div>
 
         <article id="slide-stage" class="slide-stage hidden">
-          <div id="slide-content" class="slide-content">
-            <div class="placeholder">
-              <h2>Noch keine Slideshow geladen</h2>
-              <p>Öffne ein Verzeichnis, ein SLD, ein ZIP oder eine Remote-Quelle mit <code>slides.json</code>.</p>
-            </div>
-          </div>
+          <div id="slide-content" class="slide-content"></div>
           <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
             <h3>Audioinhalt der aktuellen Folie</h3>
             <p id="transcript-hint" class="muted small"></p>
@@ -197,6 +163,35 @@
             <dt>Audio</dt><dd id="audio-status">Gestoppt</dd>
           </dl>
         </section>
+
+        <div class="project-intro panel">
+          <p class="project-links">
+            Quellen:
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer" target="_blank" rel="noreferrer">
+                      sld-slideshow-viewer
+                  </a>,
+                  <a href="https://huluvu424242.github.io/foile-pile/" target="_blank" rel="noreferrer">
+                      Präsentationen (Sammlung)
+                  </a>
+          </p>
+          <p class="project-links">
+            Dokumentation:
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/README.md" target="_blank"
+                     rel="noreferrer">Doku-Index</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/README.md" target="_blank"
+                     rel="noreferrer">README</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/createslideshow.md"
+                     target="_blank" rel="noreferrer">Create Slideshow</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/architecture.md"
+                     target="_blank" rel="noreferrer">Architektur</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/manifest.md" target="_blank"
+                     rel="noreferrer">Manifest</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/sld-spec.md" target="_blank"
+                     rel="noreferrer">SLD-Spec</a>,
+                  <a href="https://github.com/Huluvu424242/sld-slideshow-viewer/blob/master/docs/roadmap.md" target="_blank"
+                     rel="noreferrer">Roadmap</a>
+          </p>
+        </div>
       </main>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
       <h1>Slideshow Viewer</h1>
         <div id="error-box" class="error-box hidden" role="alert"></div>
 
+        <div id="showtime-progress-track" class="toolbar-progress hidden" aria-hidden="true">
+          <span id="showtime-progress" class="showtime-progress"></span>
+        </div>
+
         <article id="slide-stage" class="slide-stage hidden">
           <div id="slide-content" class="slide-content"></div>
           <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
@@ -32,9 +36,6 @@
         </article>
 
         <header id="player-toolbar" class="toolbar panel">
-          <div class="toolbar-progress">
-            <span id="showtime-progress" class="showtime-progress"></span>
-          </div>
           <div class="toolbar-group toolbar-group--primary">
             <button id="first-btn"
                     class="icon-btn icon-btn-first"

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <div class="app-shell">
-      <aside class="sidebar">
+      <main class="stage">
       <h1>Slideshow Viewer</h1>
       <div class="project-intro">
         <p class="project-links">
@@ -48,38 +48,27 @@
         </p>
       </div>
 
-        <section class="panel">
-          <h2>Quelle laden</h2>
-          <div class="stack gap-s">
-            <button id="pick-directory-btn" type="button">Lokales Verzeichnis öffnen</button>
-            <label class="file-label" for="remote-url-input">
-              <span>SLD/ZIP-Datei laden</span>
-              <input id="zip-input" type="file" accept=".sld,.zip,application/zip">
-            </label>
-            <input id="remote-url-input" type="url" placeholder="https://example.org/slides.json oder .zip oder .sld">
-            <button id="load-remote-btn" type="button">Remote laden</button>
+        <div id="error-box" class="error-box hidden" role="alert"></div>
+
+        <article id="slide-stage" class="slide-stage hidden">
+          <div id="slide-content" class="slide-content">
+            <div class="placeholder">
+              <h2>Noch keine Slideshow geladen</h2>
+              <p>Öffne ein Verzeichnis, ein SLD, ein ZIP oder eine Remote-Quelle mit <code>slides.json</code>.</p>
+            </div>
           </div>
-          <p class="muted small">Verzeichnisladen nutzt die File System Access API. ZIP und Remote funktionieren ohne Serverlogik.</p>
-        </section>
+          <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
+            <h3>Audioinhalt der aktuellen Folie</h3>
+            <p id="transcript-hint" class="muted small"></p>
+            <audio id="transcript-audio-player" controls class="hidden"></audio>
+            <pre id="transcript-text" class="hidden"></pre>
+          </section>
+        </article>
 
-        <section class="panel">
-          <h2>Status</h2>
-          <dl class="meta-grid">
-            <dt>Präsentation</dt><dd id="deck-title">–</dd>
-            <dt>Folie</dt><dd id="slide-counter">0 / 0</dd>
-            <dt>Quelle</dt><dd id="source-kind">–</dd>
-            <dt>Audio</dt><dd id="audio-status">Gestoppt</dd>
-          </dl>
-        </section>
-
-        <section class="panel">
-          <h2>Folien</h2>
-          <ol id="slide-list" class="slide-list"></ol>
-        </section>
-      </aside>
-
-      <main class="stage">
-        <header id="player-toolbar" class="toolbar">
+        <header id="player-toolbar" class="toolbar panel">
+          <div class="toolbar-progress">
+            <span id="showtime-progress" class="showtime-progress"></span>
+          </div>
           <div class="toolbar-group toolbar-group--primary">
             <button id="first-btn"
                     class="icon-btn icon-btn-first"
@@ -151,27 +140,23 @@
               data-icon="eye"
             >
             </button>
-            <label for="goto-input">Gehe zu</label>
-            <input id="goto-input" type="number" min="1" step="1" value="1">
-            <button id="goto-btn" type="button">Los</button>
             <output id="showtime-countdown" class="showtime-countdown is-safe" aria-live="polite">–</output>
             <label class="checkbox-inline">
               <input id="autoplay-next-checkbox" type="checkbox" checked>
               <span>Nächste Folie automatisch</span>
-              <button
-                id="help-toggle-btn"
-                class="icon-btn icon-btn--help"
-                type="button"
-                title="Steuerungshilfe anzeigen"
-                aria-label="Steuerungshilfe anzeigen"
-                aria-expanded="false"
-                data-icon="help"
-              >
-              </button>
             </label>
+            <button
+              id="help-toggle-btn"
+              class="icon-btn icon-btn--help"
+              type="button"
+              title="Steuerungshilfe anzeigen"
+              aria-label="Steuerungshilfe anzeigen"
+              aria-expanded="false"
+              data-icon="help"
+            >
+            </button>
           </div>
         </header>
-        <div id="error-box" class="error-box error-box--stage hidden" role="alert"></div>
         <section id="help-panel" class="help-panel hidden" aria-live="polite">
           <h3>Steuerungshilfe</h3>
           <p>Diese Befehle stehen für Folienwechsel und Wiedergabe zur Verfügung:</p>
@@ -181,23 +166,37 @@
             <li><strong>Klick im Folienbereich:</strong> Einfachklick startet/pausiert die Präsentation.</li>
             <li><strong>Doppelklick im Folienbereich:</strong> Scrollt zurück an den Anfang der Folie.</li>
             <li><strong>Touch-Gesten:</strong> Wischen links/rechts wechselt Folien, Wischen nach oben blendet den Audiotext ein bzw. aus, Tippen startet/pausiert.</li>
-            <li><strong>Gehe zu:</strong> Foliennummer eingeben und mit <em>Los</em> direkt springen.</li>
           </ul>
         </section>
 
-        <section id="transcript-panel" class="transcript-panel hidden" aria-live="polite">
-          <h3>Audioinhalt der aktuellen Folie</h3>
-          <p id="transcript-hint" class="muted small"></p>
-          <audio id="transcript-audio-player" controls class="hidden"></audio>
-          <pre id="transcript-text" class="hidden"></pre>
+        <section class="panel hidden" id="slide-list-panel">
+          <h2>Folien</h2>
+          <ol id="slide-list" class="slide-list"></ol>
         </section>
 
-        <article id="slide-stage" class="slide-stage">
-          <div class="placeholder">
-            <h2>Noch keine Slideshow geladen</h2>
-            <p>Öffne ein Verzeichnis, ein SLD, ein ZIP oder eine Remote-Quelle mit <code>slides.json</code>.</p>
+        <section class="panel">
+          <h2>Quelle laden</h2>
+          <div class="stack gap-s">
+            <button id="pick-directory-btn" type="button">Lokales Verzeichnis öffnen</button>
+            <label class="file-label" for="remote-url-input">
+              <span>SLD/ZIP-Datei laden</span>
+              <input id="zip-input" type="file" accept=".sld,.zip,application/zip">
+            </label>
+            <input id="remote-url-input" type="url" placeholder="https://example.org/slides.json oder .zip oder .sld">
+            <button id="load-remote-btn" type="button">Remote laden</button>
           </div>
-        </article>
+          <p class="muted small">Verzeichnisladen nutzt die File System Access API. ZIP und Remote funktionieren ohne Serverlogik.</p>
+        </section>
+
+        <section class="panel">
+          <h2>Status</h2>
+          <dl class="meta-grid">
+            <dt>Präsentation</dt><dd id="deck-title">–</dd>
+            <dt>Folie</dt><dd id="slide-counter">0 / 0</dd>
+            <dt>Quelle</dt><dd id="source-kind">–</dd>
+            <dt>Audio</dt><dd id="audio-status">Gestoppt</dd>
+          </dl>
+        </section>
       </main>
     </div>
 

--- a/src/app.js
+++ b/src/app.js
@@ -81,8 +81,14 @@ function createAudioController() {
     return new AudioController({
         onStatusChange(status) {
             elements.audioStatus.textContent = status;
+            const currentSlide = state.deck?.slides[state.currentIndex];
             if (status.startsWith('Spielt')) {
                 renderSpeakingIndicator();
+            } else if (status === 'Pausiert' && hasSlideAudioSource(currentSlide) && nonAudioPlaybackRemainingSeconds === null) {
+                renderShowtimeDash();
+                if (elements.showtimeProgress) {
+                    elements.showtimeProgress.style.width = '100%';
+                }
             } else if (!showtimeCountdownInterval) {
                 renderShowtimeDash();
             }
@@ -91,9 +97,6 @@ function createAudioController() {
             await handleSlidePlaybackCompleted();
         },
         onFallbackTimerStart(seconds) {
-            if (!state.autoAdvance) {
-                return;
-            }
             setPlayButtonActive(true);
             startShowtimeCountdown(null, {seconds});
         },
@@ -507,6 +510,9 @@ function renderShowtimeDash() {
 
 function renderSpeakingIndicator() {
     renderLayoutSpeakingIndicator(elements.showtimeCountdown);
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '100%';
+    }
 }
 
 function showSlideChangeCueIndicator() {

--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,7 @@ let singleTouchActionTimer = null;
 let singleClickActionTimer = null;
 let lastTouchTapTimestamp = 0;
 let transcriptRenderToken = 0;
+let showtimeCountdownTotalSeconds = null;
 
 await initApp();
 
@@ -207,8 +208,6 @@ function bindEvents() {
     });
 
     registerStageInteractionArea(elements.slideStage);
-    registerStageInteractionArea(elements.transcriptPanel);
-    registerStageInteractionArea(elements.errorBox);
 
     window.addEventListener('resize', () => {
         centerSlideStageHorizontally();
@@ -241,9 +240,7 @@ function isInteractiveControlTarget(target) {
 }
 
 function keepPlaybackButtonFocus() {
-    if (document.activeElement === elements.gotoInput) {
-        elements.playBtn.focus({preventScroll: true});
-    }
+    elements.playBtn.focus({preventScroll: true});
 }
 
 function handleTouchStart(event) {
@@ -439,6 +436,10 @@ function clearShowtimeCountdown() {
         window.clearInterval(showtimeCountdownInterval);
         showtimeCountdownInterval = null;
     }
+    showtimeCountdownTotalSeconds = null;
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '0%';
+    }
 }
 
 function setPlayButtonActive(active) {
@@ -494,10 +495,14 @@ function getSlideShowtimeSeconds(slide) {
 
 function renderShowtimeCountdown(value) {
     renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
+    renderShowtimeProgress(value);
 }
 
 function renderShowtimeDash() {
     renderLayoutShowtimeDash(elements.showtimeCountdown);
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '0%';
+    }
 }
 
 function renderSpeakingIndicator() {
@@ -511,6 +516,9 @@ function showSlideChangeCueIndicator() {
     slideChangeCueIndicatorToken += 1;
     elements.showtimeCountdown.textContent = '🔔';
     elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking');
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '100%';
+    }
     return slideChangeCueIndicatorToken;
 }
 
@@ -536,6 +544,7 @@ function startShowtimeCountdown(slide, options = {}) {
     }
 
     nonAudioPlaybackRemainingSeconds = hasOverride ? overrideSeconds : getSlideShowtimeSeconds(slide);
+    showtimeCountdownTotalSeconds = nonAudioPlaybackRemainingSeconds;
     renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
     showtimeCountdownInterval = window.setInterval(() => {
         if (nonAudioPlaybackRemainingSeconds === null) {
@@ -548,6 +557,15 @@ function startShowtimeCountdown(slide, options = {}) {
             setPlayButtonActive(false);
         }
     }, 1000);
+}
+
+function renderShowtimeProgress(remainingSeconds) {
+    if (!elements.showtimeProgress || !Number.isFinite(showtimeCountdownTotalSeconds) || showtimeCountdownTotalSeconds <= 0) {
+        return;
+    }
+    const elapsed = Math.max(0, showtimeCountdownTotalSeconds - remainingSeconds);
+    const progress = Math.max(0, Math.min(100, (elapsed / showtimeCountdownTotalSeconds) * 100));
+    elements.showtimeProgress.style.width = `${progress}%`;
 }
 
 function updateSlideAudioStatus(slide) {
@@ -786,7 +804,7 @@ async function renderCurrentSlide() {
     setPlayButtonActive(false);
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
-        elements.slideStage.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
+        elements.slideContent.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
         centerSlideStageHorizontally();
         if (elements.showtimeCountdown) {
             renderShowtimeDash();
@@ -804,7 +822,7 @@ async function renderCurrentSlide() {
     };
 
     const html = renderSlideContent(slide, assetResolver);
-    elements.slideStage.innerHTML = `
+    elements.slideContent.innerHTML = `
     <article class="slide-card" data-slide-id="${escapeHtml(slide.id || '')}">
       ${html}
     </article>
@@ -1019,9 +1037,9 @@ function refreshUi() {
     elements.deckTitle.textContent = state.deck?.title ?? '–';
     elements.sourceKind.textContent = state.sourceKind ?? '–';
     elements.slideCounter.textContent = slideCount > 0 ? `${state.currentIndex + 1} / ${slideCount}` : '0 / 0';
-    elements.gotoInput.max = String(Math.max(slideCount, 1));
-    elements.gotoInput.value = slideCount > 0 ? String(state.currentIndex + 1) : '1';
     elements.autoplayNextCheckbox.checked = state.autoAdvance;
+    elements.slideStage.classList.toggle('hidden', slideCount < 1);
+    elements.slideListPanel.classList.toggle('hidden', slideCount < 1);
 
     const disabled = !state.deck || isSlideTransitionInProgress;
     for (const button of [
@@ -1032,12 +1050,9 @@ function refreshUi() {
         elements.stopBtn,
         elements.nextBtn,
         elements.lastBtn,
-        elements.gotoBtn,
     ]) {
         button.disabled = disabled;
     }
-
-    elements.gotoInput.disabled = disabled;
     elements.transcriptToggleBtn.disabled = disabled || !hasSlideAudioSource(currentSlide);
 }
 
@@ -1057,6 +1072,7 @@ async function toggleTranscriptPanel() {
 
 function setTranscriptPanelVisibility(isVisible) {
     elements.transcriptPanel.classList.toggle('hidden', !isVisible);
+    elements.slideContent.classList.toggle('hidden', isVisible);
     updateTranscriptToggleButton(elements.transcriptToggleBtn, isVisible);
 }
 function hideTranscriptPanel() {

--- a/src/app.js
+++ b/src/app.js
@@ -377,49 +377,17 @@ function clearSingleClickActionTimer() {
 }
 
 function scrollToSlideStageTop() {
-    const top = shouldScrollToDocumentTop()
-        ? 0
-        : window.scrollY + elements.slideStage.getBoundingClientRect().top;
+    const scrollAnchor = getStageScrollAnchor();
+    const top = window.scrollY + scrollAnchor.getBoundingClientRect().top;
     window.scrollTo({top, left: 0, behavior: 'auto'});
     centerSlideStageHorizontally();
 }
 
-function shouldScrollToDocumentTop() {
-    if (hasStackedSidebarAboveStage()) {
-        return false;
+function getStageScrollAnchor() {
+    if (elements.showtimeProgressTrack && !elements.showtimeProgressTrack.classList.contains('hidden')) {
+        return elements.showtimeProgressTrack;
     }
-    return !hasVisibleContentBeforeSlideStage();
-}
-
-function hasStackedSidebarAboveStage() {
-    const stageRoot = elements.slideStage.closest('.stage');
-    if (!stageRoot) {
-        return false;
-    }
-    return stageRoot.getBoundingClientRect().top > 1;
-}
-
-function hasVisibleContentBeforeSlideStage() {
-    const stageRoot = elements.slideStage.closest('.stage');
-    if (!stageRoot) {
-        return false;
-    }
-
-    for (const child of stageRoot.children) {
-        if (child === elements.slideStage) {
-            break;
-        }
-        if (child === elements.playerToolbar) {
-            continue;
-        }
-        if (child.classList.contains('hidden')) {
-            continue;
-        }
-        if (child.getBoundingClientRect().height > 0) {
-            return true;
-        }
-    }
-    return false;
+    return elements.slideStage;
 }
 
 function centerSlideStageHorizontally() {

--- a/src/app.js
+++ b/src/app.js
@@ -804,7 +804,7 @@ async function renderCurrentSlide() {
     setPlayButtonActive(false);
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
-        elements.slideContent.innerHTML = `<div class="placeholder"><h2>Keine Folie gewählt</h2></div>`;
+        elements.slideContent.innerHTML = '';
         centerSlideStageHorizontally();
         if (elements.showtimeCountdown) {
             renderShowtimeDash();

--- a/src/app.js
+++ b/src/app.js
@@ -1045,6 +1045,7 @@ function refreshUi() {
     elements.slideCounter.textContent = slideCount > 0 ? `${state.currentIndex + 1} / ${slideCount}` : '0 / 0';
     elements.autoplayNextCheckbox.checked = state.autoAdvance;
     elements.slideStage.classList.toggle('hidden', slideCount < 1);
+    elements.showtimeProgressTrack.classList.toggle('hidden', slideCount < 1);
     elements.slideListPanel.classList.toggle('hidden', slideCount < 1);
 
     const disabled = !state.deck || isSlideTransitionInProgress;

--- a/src/app.js
+++ b/src/app.js
@@ -377,17 +377,9 @@ function clearSingleClickActionTimer() {
 }
 
 function scrollToSlideStageTop() {
-    const scrollAnchor = getStageScrollAnchor();
-    const top = window.scrollY + scrollAnchor.getBoundingClientRect().top;
+    const top = window.scrollY + elements.showtimeProgressTrack.getBoundingClientRect().top;
     window.scrollTo({top, left: 0, behavior: 'auto'});
     centerSlideStageHorizontally();
-}
-
-function getStageScrollAnchor() {
-    if (elements.showtimeProgressTrack && !elements.showtimeProgressTrack.classList.contains('hidden')) {
-        return elements.showtimeProgressTrack;
-    }
-    return elements.slideStage;
 }
 
 function centerSlideStageHorizontally() {

--- a/src/layout.js
+++ b/src/layout.js
@@ -7,9 +7,11 @@ const ELEMENT_SELECTORS = {
     audioStatus: '#audio-status',
     errorBox: '#error-box',
     playerToolbar: '#player-toolbar',
+    slideListPanel: '#slide-list-panel',
     slideList: '#slide-list',
     slideStage: '#slide-stage',
-    gotoInput: '#goto-input',
+    slideContent: '#slide-content',
+    showtimeProgress: '#showtime-progress',
     showtimeCountdown: '#showtime-countdown',
     transcriptToggleBtn: '#transcript-toggle-btn',
     transcriptPanel: '#transcript-panel',
@@ -30,7 +32,6 @@ const ELEMENT_SELECTORS = {
     stopBtn: '#stop-btn',
     nextBtn: '#next-btn',
     lastBtn: '#last-btn',
-    gotoBtn: '#goto-btn',
 };
 
 export function collectLayoutElements(root = document) {
@@ -50,7 +51,7 @@ export function renderShowtimeCountdown(element, value) {
     }
 
     const safeValue = Math.max(0, Math.floor(value));
-    element.textContent = String(safeValue);
+    element.textContent = '';
     element.classList.remove('is-speaking');
     element.classList.toggle('is-safe', safeValue > 3);
     element.classList.toggle('is-danger', safeValue <= 3);
@@ -61,7 +62,7 @@ export function renderShowtimeDash(element) {
         return;
     }
 
-    element.textContent = '–';
+    element.textContent = '';
     element.classList.remove('is-danger', 'is-safe', 'is-speaking');
 }
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -11,6 +11,7 @@ const ELEMENT_SELECTORS = {
     slideList: '#slide-list',
     slideStage: '#slide-stage',
     slideContent: '#slide-content',
+    showtimeProgressTrack: '#showtime-progress-track',
     showtimeProgress: '#showtime-progress',
     showtimeCountdown: '#showtime-countdown',
     transcriptToggleBtn: '#transcript-toggle-btn',

--- a/src/player.js
+++ b/src/player.js
@@ -16,7 +16,6 @@ export function bindPlayerButtonEvents({
     elements.prevBtn.addEventListener('click', () => goToSlide(getCurrentIndex() - 1));
     elements.nextBtn.addEventListener('click', () => goToSlide(getCurrentIndex() + 1));
     elements.lastBtn.addEventListener('click', () => goToSlide(getDeck()?.slides.length - 1 ?? -1));
-    elements.gotoBtn.addEventListener('click', () => goToSlide(Number(elements.gotoInput.value) - 1));
 
     elements.playBtn.addEventListener('click', async (event) => {
         event.preventDefault();

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,35 +33,26 @@ code {
 }
 
 .app-shell {
-    display: grid;
-    grid-template-columns: 360px 1fr;
+    display: block;
     min-height: 100vh;
-}
-
-.sidebar {
-    padding: 20px;
-    border-right: 1px solid var(--border);
-    background: linear-gradient(180deg, var(--panel), #15191f);
-    overflow: auto;
 }
 
 .stage {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    width: min(1260px, 100%);
+    margin: 0 auto;
+    padding: 20px;
+    gap: 14px;
 }
 
 .toolbar {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     gap: 16px;
     padding: 12px 18px;
-    border-bottom: 1px solid var(--border);
-    background: rgba(19, 22, 26, 0.92);
-    position: sticky;
-    top: 0;
-    z-index: 2;
 }
 
 .toolbar-group {
@@ -72,7 +63,8 @@ code {
 }
 
 .transcript-panel {
-    margin: 12px 18px 0;
+    width: min(1200px, 100%);
+    margin: 0 auto;
     padding: 12px 14px;
     border: 1px solid var(--border);
     border-radius: 14px;
@@ -302,10 +294,6 @@ input[type="url"] {
     white-space: pre-line;
 }
 
-.error-box--stage {
-    margin: 12px 18px 0;
-}
-
 .slide-list {
     margin: 0;
     padding-left: 20px;
@@ -326,19 +314,28 @@ input[type="url"] {
 }
 
 .slide-stage {
-    padding: 28px;
+    padding: 20px;
     overflow: auto;
     display: flex;
-    align-items: stretch;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
-    flex: 1;
+    flex: initial;
     touch-action: pan-y;
+    background: rgba(35, 42, 52, 0.3);
+    border: 1px solid var(--border);
+    border-radius: 18px;
 }
 
-.slide-card {
+.slide-stage .slide-content {
+    width: 100%;
+}
+
+.slide-card,
+.placeholder {
     width: min(1200px, 100%);
     margin-inline: auto;
-    min-height: calc(100vh - 120px);
+    min-height: min(70vh, 760px);
     background: linear-gradient(180deg, #f6f8fb, #e9eef6);
     color: #111827;
     border-radius: 28px;
@@ -373,15 +370,11 @@ input[type="url"] {
 }
 
 .placeholder {
-    width: min(920px, 100%);
-    margin-inline: auto;
-    min-height: calc(100vh - 120px);
     border: 2px dashed var(--border);
-    border-radius: 28px;
     display: grid;
     place-items: center;
     text-align: center;
-    color: var(--muted);
+    color: #334155;
 }
 
 .checkbox-inline {
@@ -389,6 +382,23 @@ input[type="url"] {
     align-items: center;
     gap: 8px;
     padding-left: 6px;
+}
+
+.toolbar-progress {
+    width: min(1200px, 100%);
+    margin: 0 auto;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(120, 182, 130, 0.15);
+    overflow: hidden;
+}
+
+.showtime-progress {
+    display: block;
+    width: 0%;
+    height: 100%;
+    background: #85f7a3;
+    transition: width 0.18s linear;
 }
 
 .icon-btn--help {
@@ -425,15 +435,6 @@ input[type="url"] {
 }
 
 @media (max-width: 1100px) {
-    .app-shell {
-        grid-template-columns: 1fr;
-    }
-
-    .sidebar {
-        border-right: 0;
-        border-bottom: 1px solid var(--border);
-    }
-
     .slide-card {
         padding: 28px;
         min-height: auto;


### PR DESCRIPTION
### Motivation
- Die Darstellung soll der geforderten vertikalen Reihenfolge folgen: Titel, Fehlerbereich, Folienbereich (inkl. Audiotext/Transkript), Player-Toolbar, Folienliste, Quelle laden und Status. 
- Der Fehlerbereich und die Abschnitte für Folien/Quelle sollen nur sichtbar sein, wenn relevant, um die Oberfläche übersichtlicher zu machen. 
- Die numerische Countdown-Anzeige soll durch eine laufende hellgrüne Fortschrittslinie ersetzt werden, während Glocke- und Sprechkopf-Indikatoren erhalten bleiben. 

### Description
- Die Struktur in `index.html` wurde neu angeordnet und enthält jetzt oberhalb: das Title-Heading, den Fehlerbereich (`#error-box`), den Folienbereich (`#slide-stage`/`#slide-content` mit `#transcript-panel`), die Player-Toolbar (mit neuem `#showtime-progress`) sowie die Folienliste (`#slide-list-panel`), Quelle laden und Status. 
- Die Toolbar-„Gehe zu“ Eingabe und der Button `Los` wurden entfernt und alle Hilfetexte entsprechend bereinigt, die zugehörige Eventbindung in `src/player.js` wurde entfernt. 
- Countdown-Rendering wurde in `src/layout.js` und `src/app.js` angepasst: die alte Zahl wird nicht mehr angezeigt, ein neues Element `#showtime-progress` repräsentiert die laufende Fortschrittslinie, und `src/app.js` verwaltet nun `showtimeCountdownTotalSeconds` plus die Funktion `renderShowtimeProgress` zur Breitenberechnung. 
- Sichtbarkeit und Interaktion wurden angepasst: beim Öffnen des Transkripts wird der Folieninhalt ausgeblendet (`elements.slideContent.classList.toggle('hidden', ...)`), und `src/app.js` blendet `#slide-stage` und `#slide-list-panel` aus, wenn keine Slideshow geladen ist; CSS-Anpassungen in `src/styles.css` formen das neue Layout und die Progress-Bar. 

### Testing
- Automatische Syntax-Checks wurden erfolgreich ausgeführt mit `node --check src/app.js`. 
- Automatische Syntax-Checks wurden erfolgreich ausgeführt mit `node --check src/layout.js`. 
- Automatische Syntax-Checks wurden erfolgreich ausgeführt mit `node --check src/player.js` und `node --check src/hilfe.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7cd5fa8c4832aa2b10f184494a100)