### PR TITLE
Fix: Swipe nach links navigiert zur vorherigen Folie auf Touch‑Geräten

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -283,7 +283,8 @@ async function handleTouchEnd(event) {
     resetSwipeState(swipeState);
 
     if (isHorizontalSwipe) {
-        if (horizontalDistance > 0) {
+        // On touch devices, a swipe to the left should navigate to the previous slide.
+        if (horizontalDistance < 0) {
             await goToSlide(state.currentIndex - 1);
             return;
         }


### PR DESCRIPTION
### Motivation
- Auf Android/Touch-Geräten konnte ein Swipe nach links nicht zur vorherigen Folie springen, daher wurde die Swipe-Richtungslogik angepasst, um erwartetes Verhalten wiederherzustellen.

### Description
- In `src/app.js` wurde die Bedingung für horizontale Swipes so geändert, dass `horizontalDistance < 0` die vorherige Folie (`goToSlide(state.currentIndex - 1)`) anspricht, und ein erklärender Inline-Kommentar wurde hinzugefügt.

### Testing
- Es wurde `node --check src/app.js` ausgeführt und die Prüfung verlief erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e66d62d4832aac051be423f7caf0)