### PR TITLE
Fix swapped horizontal swipe slide navigation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -281,12 +281,14 @@ async function handleTouchEnd(event) {
 
     if (isHorizontalSwipe) {
         if (horizontalDistance > 0) {
-            await goToSlide(state.currentIndex - 1);
+            await goToSlide(state.currentIndex + 1);
             return;
         }
 
-        await goToSlide(state.currentIndex + 1);
-        return;
+        if (horizontalDistance < 0) {
+            await goToSlide(state.currentIndex - 1);
+            return;
+        }
     }
 
     if (isVerticalSwipe) {


### PR DESCRIPTION
### Motivation
- The horizontal swipe gesture handling in `handleTouchEnd` produced reversed navigation, so swiping left/right did not move to the intended next/previous slide.

### Description
- Updated `src/app.js` in `handleTouchEnd` so that positive `horizontalDistance` triggers `goToSlide(state.currentIndex + 1)` and negative `horizontalDistance` triggers `goToSlide(state.currentIndex - 1)`, and added an explicit negative-distance branch to avoid fall-through.

### Testing
- Ran `node --check src/app.js` to verify the file is syntactically valid and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91290caac832aa280feae02a444ee)