### PR TITLE
Fix swipe left/right slide navigation mapping

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -283,13 +283,13 @@ async function handleTouchEnd(event) {
     resetSwipeState(swipeState);
 
     if (isHorizontalSwipe) {
-        // On touch devices, a swipe to the left should navigate to the previous slide.
+        // On touch devices, a swipe to the left should navigate to the next slide.
         if (horizontalDistance < 0) {
-            await goToSlide(state.currentIndex - 1);
+            await goToSlide(state.currentIndex + 1);
             return;
         }
 
-        await goToSlide(state.currentIndex + 1);
+        await goToSlide(state.currentIndex - 1);
         return;
     }
 


### PR DESCRIPTION
### Motivation
- The horizontal touch-swipe mapping was reversed so a left swipe did not advance to the next slide, which breaks expected navigation behavior on touch devices.

### Description
- Updated `handleTouchEnd` in `src/app.js` to treat `horizontalDistance < 0` as advancing to the next slide by calling `goToSlide(state.currentIndex + 1)` and the opposite branch to go to the previous slide.
- Adjusted the inline comment in `src/app.js` to match the corrected behavior.

### Testing
- Ran `git diff --check` to verify patch formatting and it succeeded.
- Ran `git status --short` to confirm the working tree shows the intended file change and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e916428940832a9ba7de812e9ef07b)