### PR TITLE
Add error indicator icon for showtime countdown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,7 @@ import {
     registerLayoutLifecycleHooks,
     renderShowtimeCountdown as renderLayoutShowtimeCountdown,
     renderShowtimeDash as renderLayoutShowtimeDash,
+    renderShowtimeErrorIndicator as renderLayoutShowtimeErrorIndicator,
     renderSpeakingIndicator as renderLayoutSpeakingIndicator,
     updateTranscriptToggleButton,
 } from './layout.js';
@@ -101,9 +102,16 @@ function createAudioController() {
             startShowtimeCountdown(null, {seconds});
         },
         onAudioIssue(message) {
-            showError(elements.errorBox, `⚠️ ${message}`);
+            showApplicationError(`⚠️ ${message}`);
         },
     });
+}
+
+async function withUiErrorHandling(fn) {
+    await withErrorHandling(elements.errorBox, fn);
+    if (!elements.errorBox.classList.contains('hidden')) {
+        renderShowtimeErrorIndicator();
+    }
 }
 
 function registerLifecycleHooks() {
@@ -128,7 +136,7 @@ function cleanupApplication() {
 
 function bindEvents() {
     elements.pickDirectoryBtn.addEventListener('click', async () => {
-        await withErrorHandling(elements.errorBox, async () => {
+        await withUiErrorHandling(async () => {
             const deck = await loadDeckFromDirectory();
             await setDeck(deck);
         });
@@ -139,7 +147,7 @@ function bindEvents() {
         if (!file) {
             return;
         }
-        await withErrorHandling(elements.errorBox, async () => {
+        await withUiErrorHandling(async () => {
             const deck = await loadDeckFromZip(file);
             await setDeck(deck);
             event.target.value = '';
@@ -147,7 +155,7 @@ function bindEvents() {
     });
 
     elements.loadRemoteBtn.addEventListener('click', async () => {
-        await withErrorHandling(elements.errorBox, async () => {
+        await withUiErrorHandling(async () => {
             const url = elements.remoteUrlInput.value.trim();
             if (!url) {
                 throw new Error('Bitte eine Remote-URL eingeben.');
@@ -168,7 +176,9 @@ function bindEvents() {
         pausePresentation,
         stopPresentation,
         keepPlaybackButtonFocus,
-        withErrorHandling,
+        withErrorHandling: async (_errorBox, fn) => {
+            await withUiErrorHandling(fn);
+        },
         errorBox: elements.errorBox,
     });
     bindAutoAdvanceToggle({
@@ -480,13 +490,25 @@ function renderSpeakingIndicator() {
     }
 }
 
+function renderShowtimeErrorIndicator() {
+    renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '100%';
+    }
+}
+
+function showApplicationError(message) {
+    showError(elements.errorBox, message);
+    renderShowtimeErrorIndicator();
+}
+
 function showSlideChangeCueIndicator() {
     if (!elements.showtimeCountdown) {
         return 0;
     }
     slideChangeCueIndicatorToken += 1;
     elements.showtimeCountdown.textContent = '🔔';
-    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking');
+    elements.showtimeCountdown.classList.remove('is-danger', 'is-safe', 'is-speaking', 'is-error');
     if (elements.showtimeProgress) {
         elements.showtimeProgress.style.width = '100%';
     }
@@ -619,7 +641,7 @@ async function initializeFromQueryParameters() {
 
     elements.remoteUrlInput.value = remoteUrl;
 
-    await withErrorHandling(elements.errorBox, async () => {
+    await withUiErrorHandling(async () => {
         const deck = await loadDeckFromRemote(remoteUrl);
         await setDeck(deck);
     });
@@ -837,7 +859,7 @@ async function playCurrentSlide(options = {}) {
     if (!slide) {
         return;
     }
-    await withErrorHandling(elements.errorBox, async () => {
+    await withUiErrorHandling(async () => {
         hasPresentationStarted = true;
         pausedNonAudioRemainingSeconds = null;
         if (!slide.audio) {
@@ -1140,7 +1162,7 @@ async function renderTranscriptContent({keepOpen = false} = {}) {
 
 function checkAudioSupport() {
     if (!audioController.isSpeechReallyUsable()) {
-        showError(elements.errorBox, `
+        showApplicationError(`
         ⚠️ Sprachwiedergabe wird von diesem Browser nicht unterstützt.
         👉 Bitte nutze ein Gerät mit funktionierender SpeechSynthesis, häufig funzt ein Chrome Browser.
         ℹ️ Falls eine Folie Audio per TTS benötigt, wird stattdessen eine Fallback-Showtime von 10 Sekunden verwendet.

--- a/src/icons.js
+++ b/src/icons.js
@@ -148,6 +148,19 @@ export const ICONS = Object.freeze({
     </svg>
   `,
     /*
+     * Icon: error_info
+     * Autor: Huluvu424242
+     * Lizenz: MIT
+     * Quelle: selbst erstellt
+     */
+    error_info: `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 3.8L21 19.5H3L12 3.8z" />
+        <path d="M12 9v5.1" />
+        <circle cx="12" cy="16.9" r="0.75" />
+    </svg>
+  `,
+    /*
      * Icon: speaking_head
      * Autor: Twitter
      * Lizenz: MIT

--- a/src/layout.js
+++ b/src/layout.js
@@ -54,7 +54,7 @@ export function renderShowtimeCountdown(element, value) {
 
     const safeValue = Math.max(0, Math.floor(value));
     element.textContent = '';
-    element.classList.remove('is-speaking');
+    element.classList.remove('is-speaking', 'is-error');
     element.classList.toggle('is-safe', safeValue > 3);
     element.classList.toggle('is-danger', safeValue <= 3);
 }
@@ -65,7 +65,7 @@ export function renderShowtimeDash(element) {
     }
 
     element.textContent = '';
-    element.classList.remove('is-danger', 'is-safe', 'is-speaking');
+    element.classList.remove('is-danger', 'is-safe', 'is-speaking', 'is-error');
 }
 
 export function renderSpeakingIndicator(element) {
@@ -74,8 +74,18 @@ export function renderSpeakingIndicator(element) {
     }
 
     setIcon(element, 'speaking_head');
-    element.classList.remove('is-danger', 'is-safe');
+    element.classList.remove('is-danger', 'is-safe', 'is-error');
     element.classList.add('is-speaking');
+}
+
+export function renderShowtimeErrorIndicator(element) {
+    if (!element) {
+        return;
+    }
+
+    setIcon(element, 'error_info');
+    element.classList.remove('is-danger', 'is-safe', 'is-speaking');
+    element.classList.add('is-error');
 }
 
 export function updateTranscriptToggleButton(button, isVisible) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -214,6 +214,10 @@ button:disabled {
     color: #6cc0ff;
 }
 
+.showtime-countdown.is-error {
+    color: #ffb347;
+}
+
 .showtime-countdown.is-speaking svg {
     width: 1.15em;
     height: 1.15em;
@@ -221,12 +225,25 @@ button:disabled {
     vertical-align: middle;
 }
 
-.showtime-countdown.is-speaking svg path {
+.showtime-countdown.is-speaking svg path,
+.showtime-countdown.is-error svg path {
     fill: currentColor;
 }
 
 .showtime-countdown.is-speaking svg path.speak {
     fill: #f59e0b;
+}
+
+.showtime-countdown.is-error svg {
+    width: 1.1em;
+    height: 1.1em;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.showtime-countdown.is-error svg circle {
+    fill: #13161a;
+    stroke: none;
 }
 
 input[type="url"],


### PR DESCRIPTION
### Motivation
- Provide an intuitive visual indicator inside the `#showtime-countdown` when an application or playback error occurs so users immediately recognize a problem.
- Ensure the showtime widget can display the error state consistently alongside existing safe/danger/speaking states.

### Description
- Add a new SVG icon `error_info` to `src/icons.js` (triangle with an exclamation-like mark) and include it in the `ICONS` set.
- Add `renderShowtimeErrorIndicator(element)` to `src/layout.js` and update existing `renderShowtimeCountdown`, `renderShowtimeDash` and `renderSpeakingIndicator` to clear/avoid the `is-error` state when appropriate.
- Centralize UI error handling in `src/app.js` by introducing `withUiErrorHandling`, `showApplicationError`, and `renderShowtimeErrorIndicator` calls, and wire them into existing flows (playback errors / audio issues / various `withErrorHandling` usages) so the countdown shows the error icon on failure.
- Add CSS rules in `src/styles.css` for the new `.showtime-countdown.is-error` state and SVG rendering so the icon is styled clearly as a warning.

### Testing
- Ran static checks with `node --check src/app.js`, `node --check src/layout.js`, `node --check src/icons.js`, `node --check src/error.js` and `node --check src/player.js`, and they completed without errors.
- Verified the modified files parse and the new functions are present via quick project inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a819724832aac295d810dc5b827)