### PR TITLE
Platzhalter-Strich im Showtime-Indikator entfernen

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             data-icon="eye"
           >
           </button>
-          <output id="showtime-countdown" class="showtime-countdown is-safe" aria-live="polite">–</output>
+          <output id="showtime-countdown" class="showtime-countdown is-safe" aria-live="polite"></output>
           <div id="showtime-progress-track" class="toolbar-progress hidden" aria-hidden="true">
             <span id="showtime-progress" class="showtime-progress"></span>
           </div>

--- a/src/layout.js
+++ b/src/layout.js
@@ -64,7 +64,7 @@ export function renderShowtimeDash(element) {
         return;
     }
 
-    element.textContent = '–';
+    element.textContent = '';
     element.classList.remove('is-danger', 'is-safe', 'is-speaking', 'is-error');
 }
 


### PR DESCRIPTION
### Motivation
- Wenn keine Präsentation läuft soll der Showtime-Symbolplatz leer bleiben statt ein statisches `–` anzuzeigen, damit der Platz nicht irreführend wirkt.

### Description
- Entfernt den statischen Strich aus dem initialen DOM-Output in `index.html` indem das `<output id="showtime-countdown">` leer startet.
- Aktualisiert `renderShowtimeDash` in `src/layout.js` so dass es `element.textContent = ''` setzt anstelle von `–`.

### Testing
- Automatische Prüfung `git diff --check` wurde ausgeführt und zeigte keine Probleme.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9220c3034832a987da6dd01df9964)