### PR TITLE
Fehler-Toggle unterhalb des showtime-strip hinzufügen

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,18 @@
     <div class="app-shell">
       <main class="stage">
       <h1>Slideshow Viewer</h1>
-        <div id="error-box" class="error-box hidden" role="alert"></div>
-
         <div class="showtime-strip">
+          <button
+            id="error-toggle-btn"
+            class="icon-btn icon-btn--error hidden"
+            type="button"
+            title="Fehlermeldung einblenden"
+            aria-label="Fehlermeldung einblenden"
+            aria-expanded="false"
+            aria-pressed="false"
+            data-icon="error_info"
+          >
+          </button>
           <button
             id="transcript-toggle-btn"
             class="icon-btn icon-btn--transcript"
@@ -38,6 +47,7 @@
             <span id="showtime-progress" class="showtime-progress"></span>
           </div>
         </div>
+        <div id="error-box" class="error-box hidden" role="alert"></div>
 
         <article id="slide-stage" class="slide-stage hidden">
           <div id="slide-content" class="slide-content"></div>

--- a/src/app.js
+++ b/src/app.js
@@ -28,9 +28,9 @@ import {initializeIcons, setIcon} from './icons.js';
 import {
     collectLayoutElements,
     registerLayoutLifecycleHooks,
+    updateErrorToggleButton,
     renderShowtimeCountdown as renderLayoutShowtimeCountdown,
     renderShowtimeDash as renderLayoutShowtimeDash,
-    renderShowtimeErrorIndicator as renderLayoutShowtimeErrorIndicator,
     renderSpeakingIndicator as renderLayoutSpeakingIndicator,
     updateTranscriptToggleButton,
 } from './layout.js';
@@ -67,6 +67,8 @@ let singleClickActionTimer = null;
 let lastTouchTapTimestamp = 0;
 let transcriptRenderToken = 0;
 let showtimeCountdownTotalSeconds = null;
+let currentErrorMessage = '';
+let isErrorExpanded = false;
 
 await initApp();
 
@@ -108,10 +110,12 @@ function createAudioController() {
 }
 
 async function withUiErrorHandling(fn) {
-    await withErrorHandling(elements.errorBox, fn);
-    if (!elements.errorBox.classList.contains('hidden')) {
-        renderShowtimeErrorIndicator();
-    }
+    clearApplicationError();
+    await withErrorHandling(elements.errorBox, fn, {
+        onError(message) {
+            showApplicationError(message);
+        },
+    });
 }
 
 function registerLifecycleHooks() {
@@ -201,6 +205,10 @@ function bindEvents() {
             elements.autoplayNextCheckbox.checked = previousAutoAdvance;
             syncAutoSlideChangeForCurrentSlide();
         }
+    });
+    elements.errorToggleBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        toggleErrorMessageVisibility();
     });
 
     document.addEventListener('keydown', async (event) => {
@@ -472,20 +480,11 @@ function getSlideShowtimeSeconds(slide) {
 }
 
 function renderShowtimeCountdown(value) {
-    if (isErrorVisible()) {
-        renderShowtimeErrorIndicator();
-        renderShowtimeProgress(value);
-        return;
-    }
     renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
     renderShowtimeProgress(value);
 }
 
 function renderShowtimeDash() {
-    if (isErrorVisible()) {
-        renderShowtimeErrorIndicator();
-        return;
-    }
     renderLayoutShowtimeDash(elements.showtimeCountdown);
     if (elements.showtimeProgress) {
         elements.showtimeProgress.style.width = '0%';
@@ -493,24 +492,41 @@ function renderShowtimeDash() {
 }
 
 function renderSpeakingIndicator() {
-    if (isErrorVisible()) {
-        renderShowtimeErrorIndicator();
-        return;
-    }
     renderLayoutSpeakingIndicator(elements.showtimeCountdown);
 }
 
-function renderShowtimeErrorIndicator() {
-    renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
-}
-
 function showApplicationError(message) {
-    showError(elements.errorBox, message);
-    renderShowtimeErrorIndicator();
+    currentErrorMessage = String(message ?? '').trim();
+    isErrorExpanded = false;
+    hideError(elements.errorBox);
+    updateErrorToggleButtonState();
 }
 
-function isErrorVisible() {
-    return elements.errorBox && !elements.errorBox.classList.contains('hidden');
+function clearApplicationError() {
+    currentErrorMessage = '';
+    isErrorExpanded = false;
+    hideError(elements.errorBox);
+    updateErrorToggleButtonState();
+}
+
+function toggleErrorMessageVisibility() {
+    if (!currentErrorMessage) {
+        return;
+    }
+    isErrorExpanded = !isErrorExpanded;
+    if (isErrorExpanded) {
+        showError(elements.errorBox, currentErrorMessage);
+    } else {
+        hideError(elements.errorBox);
+    }
+    updateErrorToggleButtonState();
+}
+
+function updateErrorToggleButtonState() {
+    updateErrorToggleButton(elements.errorToggleBtn, {
+        hasError: Boolean(currentErrorMessage),
+        isExpanded: isErrorExpanded,
+    });
 }
 
 function showSlideChangeCueIndicator() {

--- a/src/app.js
+++ b/src/app.js
@@ -34,7 +34,7 @@ import {
     renderSpeakingIndicator as renderLayoutSpeakingIndicator,
     updateTranscriptToggleButton,
 } from './layout.js';
-import {showError, withErrorHandling} from './error.js';
+import {hideError, showError, withErrorHandling} from './error.js';
 import {toggleHelpPanel} from './hilfe.js';
 import {
     bindAutoAdvanceToggle,

--- a/src/error.js
+++ b/src/error.js
@@ -8,11 +8,17 @@ export function hideError(errorBox) {
     errorBox.textContent = '';
 }
 
-export async function withErrorHandling(errorBox, fn) {
+export async function withErrorHandling(errorBox, fn, options = {}) {
+    const {onError} = options;
     try {
         hideError(errorBox);
         await fn();
     } catch (error) {
-        showError(errorBox, error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        if (typeof onError === 'function') {
+            onError(message);
+            return;
+        }
+        showError(errorBox, message);
     }
 }

--- a/src/layout.js
+++ b/src/layout.js
@@ -15,6 +15,7 @@ const ELEMENT_SELECTORS = {
     showtimeProgressTrack: '#showtime-progress-track',
     showtimeProgress: '#showtime-progress',
     showtimeCountdown: '#showtime-countdown',
+    errorToggleBtn: '#error-toggle-btn',
     transcriptToggleBtn: '#transcript-toggle-btn',
     transcriptPanel: '#transcript-panel',
     transcriptHint: '#transcript-hint',
@@ -97,6 +98,20 @@ export function updateTranscriptToggleButton(button, isVisible) {
     button.classList.toggle('is-open', isVisible);
 
     const tooltipText = isVisible ? 'Audiotext ausblenden' : 'Audiotext einblenden';
+    button.title = tooltipText;
+    button.setAttribute('aria-label', tooltipText);
+}
+
+export function updateErrorToggleButton(button, {hasError, isExpanded}) {
+    button.classList.toggle('hidden', !hasError);
+    button.disabled = !hasError;
+    button.classList.toggle('is-active', hasError && isExpanded);
+    button.setAttribute('aria-expanded', String(hasError && isExpanded));
+    button.setAttribute('aria-pressed', String(hasError && isExpanded));
+
+    const tooltipText = hasError
+        ? (isExpanded ? 'Fehlermeldung ausblenden' : 'Fehlermeldung einblenden')
+        : 'Keine Fehlermeldung vorhanden';
     button.title = tooltipText;
     button.setAttribute('aria-label', tooltipText);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,6 +174,15 @@ button:disabled {
     display: block;
 }
 
+.icon-btn--error {
+    color: #ffb347;
+}
+
+.icon-btn--error.is-active {
+    border-color: rgba(255, 179, 71, 0.7);
+    box-shadow: 0 0 0 2px rgba(255, 179, 71, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
 .toolbar-group--primary {
     gap: 10px;
     flex-wrap: nowrap;
@@ -318,6 +327,8 @@ input[type="url"] {
 }
 
 .error-box {
+    width: min(1200px, 100%);
+    margin: 0 auto;
     margin-top: 14px;
     padding: 10px 12px;
     border-radius: 12px;


### PR DESCRIPTION
### Motivation
- Fehlernachrichten sollen unterhalb des `showtime-strip` erscheinen und nur auf Wunsch des Nutzers sichtbar werden, statt automatisch den Countdown visuell zu beeinflussen.

### Description
- Positioniert die Error-Box unter dem `showtime-strip` in `index.html` und fügt im Strip einen neuen Toggle-Button `#error-toggle-btn` hinzu.
- Ergänzt `src/layout.js` um den Selector `errorToggleBtn` und die Hilfsfunktion `updateErrorToggleButton()` zur Pflege von Sichtbarkeit, `aria-*`-Attributen und aktivem Zustand des Toggles.
- Erweitert `src/error.js` die Funktion `withErrorHandling()` um ein optionales `onError`-Callback, damit Fehler intern gespeichert werden können, ohne sie sofort anzuzeigen.
- Implementiert in `src/app.js` Zustand und Flow für die neue Fehler-UX (`currentErrorMessage`, `isErrorExpanded`), Register/Handler für `#error-toggle-btn` sowie Funktionen `showApplicationError()`, `clearApplicationError()`, `toggleErrorMessageVisibility()` und `updateErrorToggleButtonState()`; der Showtime-Countdown bleibt dabei unverändert sichtbar/funktional.
- Fügt in `src/styles.css` Styling für den neuen Error-Button und eine an den Strip angeglichene Breite der Error-Box hinzu.

### Testing
- Repository integrity and basic statics checks were executed against the modified files and reported no issues (file selectors present and CSS applied).
- Local validation confirmed the new selectors and functions are discoverable via `collectLayoutElements()` and that the error toggle shows/hides the `#error-box` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e937c1e674832a8762d5ace36ab0fd)