### PR TITLE
Integrate error toggle into showtime indicator slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,17 +21,6 @@
       <h1>Slideshow Viewer</h1>
         <div class="showtime-strip">
           <button
-            id="error-toggle-btn"
-            class="icon-btn icon-btn--error hidden"
-            type="button"
-            title="Fehlermeldung einblenden"
-            aria-label="Fehlermeldung einblenden"
-            aria-expanded="false"
-            aria-pressed="false"
-            data-icon="error_info"
-          >
-          </button>
-          <button
             id="transcript-toggle-btn"
             class="icon-btn icon-btn--transcript"
             type="button"
@@ -42,7 +31,16 @@
             data-icon="eye"
           >
           </button>
-          <output id="showtime-countdown" class="showtime-countdown is-safe" aria-live="polite"></output>
+          <button
+            id="showtime-countdown"
+            class="showtime-countdown is-safe"
+            type="button"
+            title="Keine Fehlermeldung vorhanden"
+            aria-label="Keine Fehlermeldung vorhanden"
+            aria-expanded="false"
+            aria-pressed="false"
+            aria-live="polite"
+          ></button>
           <div id="showtime-progress-track" class="toolbar-progress hidden" aria-hidden="true">
             <span id="showtime-progress" class="showtime-progress"></span>
           </div>

--- a/src/app.js
+++ b/src/app.js
@@ -480,13 +480,17 @@ function getSlideShowtimeSeconds(slide) {
 }
 
 function renderShowtimeCountdown(value) {
-    renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
+    if (currentErrorMessage && !isSlideChangeCueIndicatorVisible()) {
+        renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
+    } else {
+        renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
+    }
     renderShowtimeProgress(value);
     updateShowtimeErrorToggleState();
 }
 
 function renderShowtimeDash() {
-    if (currentErrorMessage && nonAudioPlaybackRemainingSeconds === null && !isSlideChangeCueIndicatorVisible()) {
+    if (currentErrorMessage && !isSlideChangeCueIndicatorVisible()) {
         renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
     } else {
         renderLayoutShowtimeDash(elements.showtimeCountdown);
@@ -558,7 +562,7 @@ function updateShowtimeIndicatorState() {
         return;
     }
 
-    if (currentErrorMessage && nonAudioPlaybackRemainingSeconds === null) {
+    if (currentErrorMessage) {
         renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
     } else if (elements.audioStatus.textContent.startsWith('Spielt')) {
         renderLayoutSpeakingIndicator(elements.showtimeCountdown);

--- a/src/app.js
+++ b/src/app.js
@@ -28,10 +28,10 @@ import {initializeIcons, setIcon} from './icons.js';
 import {
     collectLayoutElements,
     registerLayoutLifecycleHooks,
-    updateErrorToggleButton,
     renderShowtimeCountdown as renderLayoutShowtimeCountdown,
     renderShowtimeDash as renderLayoutShowtimeDash,
     renderSpeakingIndicator as renderLayoutSpeakingIndicator,
+    renderShowtimeErrorIndicator as renderLayoutShowtimeErrorIndicator,
     updateTranscriptToggleButton,
 } from './layout.js';
 import {hideError, showError, withErrorHandling} from './error.js';
@@ -206,7 +206,7 @@ function bindEvents() {
             syncAutoSlideChangeForCurrentSlide();
         }
     });
-    elements.errorToggleBtn.addEventListener('click', (event) => {
+    elements.showtimeCountdown.addEventListener('click', (event) => {
         event.preventDefault();
         toggleErrorMessageVisibility();
     });
@@ -482,35 +482,46 @@ function getSlideShowtimeSeconds(slide) {
 function renderShowtimeCountdown(value) {
     renderLayoutShowtimeCountdown(elements.showtimeCountdown, value);
     renderShowtimeProgress(value);
+    updateShowtimeErrorToggleState();
 }
 
 function renderShowtimeDash() {
-    renderLayoutShowtimeDash(elements.showtimeCountdown);
+    if (currentErrorMessage && nonAudioPlaybackRemainingSeconds === null && !isSlideChangeCueIndicatorVisible()) {
+        renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
+    } else {
+        renderLayoutShowtimeDash(elements.showtimeCountdown);
+    }
     if (elements.showtimeProgress) {
         elements.showtimeProgress.style.width = '0%';
     }
+    updateShowtimeErrorToggleState();
 }
 
 function renderSpeakingIndicator() {
-    renderLayoutSpeakingIndicator(elements.showtimeCountdown);
+    if (currentErrorMessage && !isSlideChangeCueIndicatorVisible()) {
+        renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
+    } else {
+        renderLayoutSpeakingIndicator(elements.showtimeCountdown);
+    }
+    updateShowtimeErrorToggleState();
 }
 
 function showApplicationError(message) {
     currentErrorMessage = String(message ?? '').trim();
     isErrorExpanded = false;
     hideError(elements.errorBox);
-    updateErrorToggleButtonState();
+    updateShowtimeIndicatorState();
 }
 
 function clearApplicationError() {
     currentErrorMessage = '';
     isErrorExpanded = false;
     hideError(elements.errorBox);
-    updateErrorToggleButtonState();
+    updateShowtimeIndicatorState();
 }
 
 function toggleErrorMessageVisibility() {
-    if (!currentErrorMessage) {
+    if (!currentErrorMessage || elements.showtimeCountdown.disabled) {
         return;
     }
     isErrorExpanded = !isErrorExpanded;
@@ -519,14 +530,50 @@ function toggleErrorMessageVisibility() {
     } else {
         hideError(elements.errorBox);
     }
-    updateErrorToggleButtonState();
+    updateShowtimeIndicatorState();
 }
 
-function updateErrorToggleButtonState() {
-    updateErrorToggleButton(elements.errorToggleBtn, {
-        hasError: Boolean(currentErrorMessage),
-        isExpanded: isErrorExpanded,
-    });
+function isSlideChangeCueIndicatorVisible() {
+    return elements.showtimeCountdown?.dataset.icon === 'glocke';
+}
+
+function updateShowtimeErrorToggleState() {
+    const hasError = Boolean(currentErrorMessage);
+    const isInteractive = hasError && elements.showtimeCountdown.classList.contains('is-error');
+    elements.showtimeCountdown.disabled = !isInteractive;
+    elements.showtimeCountdown.classList.toggle('is-active', hasError && isErrorExpanded && isInteractive);
+    elements.showtimeCountdown.setAttribute('aria-expanded', String(hasError && isErrorExpanded && isInteractive));
+    elements.showtimeCountdown.setAttribute('aria-pressed', String(hasError && isErrorExpanded && isInteractive));
+
+    const tooltipText = hasError
+        ? (isErrorExpanded ? 'Fehlermeldung ausblenden' : 'Fehlermeldung einblenden')
+        : 'Keine Fehlermeldung vorhanden';
+    elements.showtimeCountdown.title = tooltipText;
+    elements.showtimeCountdown.setAttribute('aria-label', tooltipText);
+}
+
+function updateShowtimeIndicatorState() {
+    if (isSlideChangeCueIndicatorVisible()) {
+        updateShowtimeErrorToggleState();
+        return;
+    }
+
+    if (currentErrorMessage && nonAudioPlaybackRemainingSeconds === null) {
+        renderLayoutShowtimeErrorIndicator(elements.showtimeCountdown);
+    } else if (elements.audioStatus.textContent.startsWith('Spielt')) {
+        renderLayoutSpeakingIndicator(elements.showtimeCountdown);
+    } else if (nonAudioPlaybackRemainingSeconds !== null) {
+        renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
+        return;
+    } else {
+        renderShowtimeDash();
+        return;
+    }
+
+    if (elements.showtimeProgress) {
+        elements.showtimeProgress.style.width = '0%';
+    }
+    updateShowtimeErrorToggleState();
 }
 
 function showSlideChangeCueIndicator() {
@@ -539,6 +586,7 @@ function showSlideChangeCueIndicator() {
     if (elements.showtimeProgress) {
         elements.showtimeProgress.style.width = '100%';
     }
+    updateShowtimeErrorToggleState();
     return slideChangeCueIndicatorToken;
 }
 
@@ -546,11 +594,7 @@ function restoreShowtimeCountdownAfterCue(token) {
     if (!elements.showtimeCountdown || token !== slideChangeCueIndicatorToken) {
         return;
     }
-    if (nonAudioPlaybackRemainingSeconds !== null) {
-        renderShowtimeCountdown(nonAudioPlaybackRemainingSeconds);
-        return;
-    }
-    renderShowtimeDash();
+    updateShowtimeIndicatorState();
 }
 
 function startShowtimeCountdown(slide, options = {}) {

--- a/src/app.js
+++ b/src/app.js
@@ -69,6 +69,7 @@ let transcriptRenderToken = 0;
 let showtimeCountdownTotalSeconds = null;
 let currentErrorMessage = '';
 let isErrorExpanded = false;
+let isPausedByErrorToggle = false;
 
 await initApp();
 
@@ -208,7 +209,7 @@ function bindEvents() {
     });
     elements.showtimeCountdown.addEventListener('click', (event) => {
         event.preventDefault();
-        toggleErrorMessageVisibility();
+        void toggleErrorMessageVisibility();
     });
 
     document.addEventListener('keydown', async (event) => {
@@ -524,17 +525,36 @@ function clearApplicationError() {
     updateShowtimeIndicatorState();
 }
 
-function toggleErrorMessageVisibility() {
+async function toggleErrorMessageVisibility() {
     if (!currentErrorMessage || elements.showtimeCountdown.disabled) {
         return;
     }
+
+    const wasRunningBeforeToggle = isPresentationRunning();
     isErrorExpanded = !isErrorExpanded;
     if (isErrorExpanded) {
         showError(elements.errorBox, currentErrorMessage);
+        if (wasRunningBeforeToggle) {
+            await pausePresentation();
+            isPausedByErrorToggle = true;
+        } else {
+            isPausedByErrorToggle = false;
+        }
     } else {
         hideError(elements.errorBox);
+        if (isPausedByErrorToggle) {
+            isPausedByErrorToggle = false;
+            await resumePresentation();
+        }
     }
     updateShowtimeIndicatorState();
+}
+
+function clearErrorPauseByInteraction() {
+    if (!isPausedByErrorToggle) {
+        return;
+    }
+    isPausedByErrorToggle = false;
 }
 
 function isSlideChangeCueIndicatorVisible() {
@@ -746,6 +766,7 @@ async function setDeck(deck) {
 }
 
 async function goToSlide(index, options = {}) {
+    clearErrorPauseByInteraction();
     if (isSlideTransitionInProgress) {
         return;
     }
@@ -934,6 +955,7 @@ async function hydrateAsyncAssets() {
 }
 
 async function playCurrentSlide(options = {}) {
+    clearErrorPauseByInteraction();
     if (isSlideTransitionInProgress && !options.ignoreTransitionLock) {
         return;
     }
@@ -1018,6 +1040,7 @@ async function pausePresentation() {
 }
 
 async function resumePresentation() {
+    clearErrorPauseByInteraction();
     if (!hasPresentationStarted) {
         return;
     }
@@ -1046,6 +1069,7 @@ async function resumePresentation() {
 }
 
 async function stopPresentation() {
+    clearErrorPauseByInteraction();
     clearSlideAdvanceTimer();
     clearShowtimeCountdown();
     nonAudioPlaybackRemainingSeconds = null;
@@ -1138,6 +1162,7 @@ function hasSlideAudioSource(slide) {
 }
 
 async function toggleTranscriptPanel() {
+    clearErrorPauseByInteraction();
     const shouldOpen = !isTranscriptPanelOpen();
     if (shouldOpen) {
         await renderTranscriptContent({keepOpen: true});

--- a/src/layout.js
+++ b/src/layout.js
@@ -15,7 +15,6 @@ const ELEMENT_SELECTORS = {
     showtimeProgressTrack: '#showtime-progress-track',
     showtimeProgress: '#showtime-progress',
     showtimeCountdown: '#showtime-countdown',
-    errorToggleBtn: '#error-toggle-btn',
     transcriptToggleBtn: '#transcript-toggle-btn',
     transcriptPanel: '#transcript-panel',
     transcriptHint: '#transcript-hint',
@@ -98,20 +97,6 @@ export function updateTranscriptToggleButton(button, isVisible) {
     button.classList.toggle('is-open', isVisible);
 
     const tooltipText = isVisible ? 'Audiotext ausblenden' : 'Audiotext einblenden';
-    button.title = tooltipText;
-    button.setAttribute('aria-label', tooltipText);
-}
-
-export function updateErrorToggleButton(button, {hasError, isExpanded}) {
-    button.classList.toggle('hidden', !hasError);
-    button.disabled = !hasError;
-    button.classList.toggle('is-active', hasError && isExpanded);
-    button.setAttribute('aria-expanded', String(hasError && isExpanded));
-    button.setAttribute('aria-pressed', String(hasError && isExpanded));
-
-    const tooltipText = hasError
-        ? (isExpanded ? 'Fehlermeldung ausblenden' : 'Fehlermeldung einblenden')
-        : 'Keine Fehlermeldung vorhanden';
     button.title = tooltipText;
     button.setAttribute('aria-label', tooltipText);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,14 +174,6 @@ button:disabled {
     display: block;
 }
 
-.icon-btn--error {
-    color: #ffb347;
-}
-
-.icon-btn--error.is-active {
-    border-color: rgba(255, 179, 71, 0.7);
-    box-shadow: 0 0 0 2px rgba(255, 179, 71, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
 
 .toolbar-group--primary {
     gap: 10px;
@@ -211,6 +203,23 @@ button:disabled {
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
+
+.showtime-countdown {
+    cursor: default;
+}
+
+.showtime-countdown:disabled {
+    opacity: 1;
+}
+
+.showtime-countdown.is-error {
+    cursor: pointer;
+}
+
+.showtime-countdown.is-error.is-active {
+    border-color: rgba(255, 179, 71, 0.7);
+    box-shadow: 0 0 0 2px rgba(255, 179, 71, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
 .showtime-countdown.is-safe {
     color: #6ee7a8;
 }


### PR DESCRIPTION
### Motivation
- Replace the separate error toggle control with the second symbol slot so the error triangle is shown and toggled in the same place as the showtime indicator. 
- Ensure rendering priority for that slot is `glocke` (bell) > error triangle > speaking head > blank/countdown, while keeping bell and speaking as display-only states. 
- Make the error triangle an interactive toggle only when it is visible and preserve existing visual states for safe/danger/speaking/error.

### Description
- Convert the dedicated error button into an integrated showtime button by removing the `#error-toggle-btn` element and changing the countdown `output` into a `button` with id `showtime-countdown` in `index.html`. 
- Remove the `errorToggleBtn` selector and `updateErrorToggleButton` helper from `src/layout.js` and keep the `renderShowtime*` helpers including a `renderShowtimeErrorIndicator`. 
- In `src/app.js` move the click handler to `elements.showtimeCountdown`, add `isSlideChangeCueIndicatorVisible`, `updateShowtimeErrorToggleState` and `updateShowtimeIndicatorState` helpers, and update rendering to prefer bell > error > speaking > dash; ensure the error-toggle is enabled only when the error icon is visible and not shadowed by the bell cue. 
- Adjust `toggleErrorMessageVisibility` to be no-op when the integrated countdown button is not interactive, and wire state updates so the new button shows `is-active`, `aria-pressed` and tooltips when appropriate. 
- Update `src/styles.css` to remove the old `.icon-btn--error` rules and add interactive styles for `.showtime-countdown` in error/active states (pointer and active highlight) while preserving existing safe/danger/speaking/error color rules.

### Testing
- Ran `node --check src/app.js` and it succeeded. 
- Ran `node --check src/layout.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93bed751c832aae663cfcfe8044cd)