### PR TITLE
Increase size of error countdown SVG for better visibility

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -253,8 +253,8 @@ button:disabled {
 }
 
 .showtime-countdown.is-error svg {
-    width: 1.1em;
-    height: 1.1em;
+    width: 1.45em;
+    height: 1.45em;
     display: inline-block;
     vertical-align: middle;
 }


### PR DESCRIPTION
### Motivation
- Increase visibility of the error-state icon by enlarging the SVG used in the countdown error UI in `styles.css`.

### Description
- Adjusted the `width` and `height` of the `.showtime-countdown.is-error svg` selector from `1.1em` to `1.45em` in `src/styles.css`.

### Testing
- Ran `npm test` and `npm run lint` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9472b6bec832ab1e513139be9ec64)