### PR TITLE
Adjust toolbar placement for tablet and larger screens

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -494,6 +494,20 @@ input[type="url"] {
     }
 }
 
+
+@media (min-width: 821px) {
+    .stage > h1 {
+        order: -2;
+    }
+
+    #player-toolbar {
+        order: -1;
+        position: sticky;
+        top: 10px;
+        z-index: 20;
+    }
+}
+
 @media (max-width: 820px) {
     .toolbar {
         flex-wrap: wrap;


### PR DESCRIPTION
### Motivation
- Auf Tablet- und Desktop-Breiten soll die Player-Toolbar zwischen der Seitenüberschrift `Slideshow Viewer` und dem `showtime-strip` angezeigt werden und nicht mehr unterhalb des Folienbereichs liegen, damit die Steuerung sichtbar bleibt; auf Phones bleibt das bestehende Layout erhalten.
- Keine Skills verwendet; Änderung ist eine kleine CSS-Anpassung an der responsiven Reihenfolge und Positionierung.

### Description
- Ergänzt eine Media-Query `@media (min-width: 821px)` in `src/styles.css` die die Reihenfolge der Flex-Items ändert, indem `.stage > h1` auf `order: -2` und `#player-toolbar` auf `order: -1` gesetzt wird.
- Macht die Toolbar ab Tablet-Breiten `position: sticky` mit `top: 10px` und `z-index: 20`, damit sie beim Scrollen sichtbar bleibt.
- Das Verhalten für `max-width: 820px` (Phone) bleibt unverändert.

### Testing
- Inspektion des Diffs mit `git diff -- src/styles.css` zeigte die erwarteten CSS-Änderungen und die neue Media-Query, Ergebnis: erfolgreich.
- Prüfen des Arbeitsbaums mit `git status --short` und anschließender Commit-Ausführung war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea540d17bc832aba14257860530f99)