### PR TITLE
Adjust toolbar layout behavior for tablet and desktop

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -496,15 +496,23 @@ input[type="url"] {
 
 
 @media (min-width: 821px) {
-    .stage > h1 {
-        order: -2;
+    #player-toolbar {
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
     }
 
-    #player-toolbar {
-        order: -1;
-        position: sticky;
-        top: 10px;
-        z-index: 20;
+    #player-toolbar .toolbar-group--primary {
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    #player-toolbar .toolbar-group--primary + .toolbar-group {
+        margin-left: auto;
+        flex: 0 1 auto;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Entfernen des Sticky-/Reorder-Verhaltens der Player-Toolbar auf Tablet und Desktop, damit nachfolgende Bereiche nicht mehr unter die Toolbar rutschen und die Seitennavigation wieder natürlich von oben nach unten fließt.
- Die Hilfs-Controls (Checkbox "Nächste Folie automatisch" und Hilfe-Button) sollen rechts an die Player-Buttons angrenzen und sich bei Platzmangel wie bisher umbrechen.
- Keine Änderungen am Phone-Layout erwünscht.

### Description
- Aktualisiert `src/styles.css` um die Desktop/Tablet-Regeln unter `@media (min-width: 821px)` zu ersetzen und die Sticky-/Order-Eigenschaften zu entfernen.
- Fügt neue Flex-Regeln für `#player-toolbar` hinzu, die `flex-direction: row`, `flex-wrap: wrap`, `align-items: center` und `gap: 10px` setzen.
- Stellt `#player-toolbar .toolbar-group--primary` so ein, dass sie als flexible Hauptgruppe (`flex: 1 1 auto`) mit Wrapping fungiert und begrenzt die minimale Breite (`min-width: 0`).
- Platziert die sekundäre Toolbar-Gruppe (Checkbox + Help) rechts mittels `margin-left: auto` und verhindert Zeilenumbruch innerhalb der Gruppe mit `white-space: nowrap`.

### Testing
- Keine automatisierten Tests ausgeführt, da es sich um eine CSS-only-Änderung handelt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea56b85328832aa7a2f14634e8c733)