### PR TITLE
Player-Toolbar und Hilfepanel auf Tablet/Desktop neu anordnen

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -497,6 +497,26 @@ input[type="url"] {
 
 @media (min-width: 821px) {
     #player-toolbar {
+        order: 1;
+    }
+
+    #help-panel {
+        order: 2;
+    }
+
+    .showtime-strip {
+        order: 3;
+    }
+
+    #error-box {
+        order: 4;
+    }
+
+    #slide-stage {
+        order: 5;
+    }
+
+    #player-toolbar {
         flex-direction: row;
         flex-wrap: wrap;
         align-items: center;


### PR DESCRIPTION
### Motivation
- Auf größeren Displays (ab Tablet) soll die Player-Toolbar direkt unter der Seitenüberschrift erscheinen und die Steuerungshilfe (`#help-panel`) direkt darunter, während `showtime-strip` und der Slide-Bereich danach folgen, um die Bedienung übersichtlicher zu machen.

### Description
- In `src/styles.css` unter `@media (min-width: 821px)` wurden `order`-Regeln ergänzt für `#player-toolbar`, `#help-panel`, `.showtime-strip`, `#error-box` und `#slide-stage` um die gewünschte visuelle Reihenfolge sicherzustellen.
- Die bestehenden Tablet-Regeln für die Toolbar-Darstellung (`flex-direction`, `flex-wrap`, `align-items`) bleiben unverändert und greifen weiterhin.
- Betroffene Datei: `src/styles.css` (responsive CSS-Änderung, keine JS-Änderungen). 

### Testing
- Es gibt kein automatisiertes Test-Setup in diesem Repository (kein `package.json`), daher wurden keine automatischen Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5895ff58832a90c0b740d492aa87)