### PR TITLE
Add IDs to panels and define desktop layout ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           <ol id="slide-list" class="slide-list"></ol>
         </section>
 
-        <section class="panel">
+        <section id="source-panel" class="panel">
           <h2>Quelle laden</h2>
           <div class="stack gap-s">
             <button id="pick-directory-btn" type="button">Lokales Verzeichnis öffnen</button>
@@ -165,7 +165,7 @@
           <p class="muted small">Verzeichnisladen nutzt die File System Access API. ZIP und Remote funktionieren ohne Serverlogik.</p>
         </section>
 
-        <section class="panel">
+        <section id="status-panel" class="panel">
           <h2>Status</h2>
           <dl class="meta-grid">
             <dt>Präsentation</dt><dd id="deck-title">–</dd>

--- a/src/styles.css
+++ b/src/styles.css
@@ -496,6 +496,46 @@ input[type="url"] {
 
 
 @media (min-width: 821px) {
+    .stage > h1 {
+        order: 1;
+    }
+
+    #player-toolbar {
+        order: 2;
+    }
+
+    #help-panel {
+        order: 3;
+    }
+
+    .showtime-strip {
+        order: 4;
+    }
+
+    #error-box {
+        order: 5;
+    }
+
+    #slide-stage {
+        order: 6;
+    }
+
+    #slide-list-panel {
+        order: 7;
+    }
+
+    #source-panel {
+        order: 8;
+    }
+
+    #status-panel {
+        order: 9;
+    }
+
+    .project-intro {
+        order: 10;
+    }
+
     #player-toolbar {
         flex-direction: row;
         flex-wrap: wrap;


### PR DESCRIPTION
### Motivation
- Ensure a predictable panel ordering on wider screens and make specific panels targetable from CSS/JS by adding IDs and explicit `order` values.

### Description
- Add `id="source-panel"` and `id="status-panel"` to the corresponding `<section>` elements in `index.html` for direct selection.
- Add ordering rules under `@media (min-width: 821px)` in `src/styles.css` that set `order` for `.stage > h1`, `#player-toolbar`, `#help-panel`, `.showtime-strip`, `#error-box`, `#slide-stage`, `#slide-list-panel`, `#source-panel`, `#status-panel`, and `.project-intro`.
- Preserve existing toolbar flex layout and responsive rules while introducing the explicit desktop ordering.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5895ff58832a90c0b740d492aa87)