### PR TITLE
Adjust tablet/desktop layout section ordering

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -500,19 +500,19 @@ input[type="url"] {
         order: 1;
     }
 
-    #player-toolbar {
+    .showtime-strip {
         order: 2;
     }
 
-    #help-panel {
+    #error-box {
         order: 3;
     }
 
-    .showtime-strip {
+    #player-toolbar {
         order: 4;
     }
 
-    #error-box {
+    #help-panel {
         order: 5;
     }
 
@@ -534,26 +534,6 @@ input[type="url"] {
 
     .project-intro {
         order: 10;
-    }
-
-    #player-toolbar {
-        order: 1;
-    }
-
-    #help-panel {
-        order: 2;
-    }
-
-    .showtime-strip {
-        order: 3;
-    }
-
-    #error-box {
-        order: 4;
-    }
-
-    #slide-stage {
-        order: 5;
     }
 
     #player-toolbar {


### PR DESCRIPTION
### Motivation
- Die Anordnung der Bereiche für Tablet/Desktop sollte der vorgegebenen Sollreihenfolge von oben nach unten entsprechen (Überschrift, Showtime-Strip, Fehlerbereich, Playertoolbar, Steuerungshilfe, Darstellungs-/Audiobereich, Folienliste, Quellenladen, Status, Hinweisbereich). 

### Description
- Die `@media (min-width: 821px)`-Regeln in `src/styles.css` wurden angepasst, sodass die `order`-Werte der Stage-Elemente der gewünschten Reihenfolge entsprechen. 
- Dubletten und widersprüchliche `order`-Deklarationen innerhalb derselben Media-Query wurden entfernt, damit die Reihenfolge deterministisch ist. 
- Das Phone-Layout (`@media (max-width: 820px)`) wurde nicht verändert.

### Testing
- Die geänderte CSS-Sektion wurde per statischer Inspektion mit `nl -ba src/styles.css | sed -n '492,570p'` geprüft und die neuen `order`-Werte wurden bestätigt (erfolgreich). 
- Die Dateiänderungen wurden per Inhaltsdiff überprüft, um sicherzustellen, dass nur die beabsichtigten `order`-Änderungen vorgenommen wurden (erfolgreich). 
- Es wurden keine Laufzeit-/Browser-Rendering- oder automatisierten UI-Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5d501d94832a99416551700a8b44)