### PR TITLE
Improve mobile slide viewport usage for SVG-heavy slides

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -557,6 +557,17 @@ input[type="url"] {
 }
 
 @media (max-width: 820px) {
+    .stage {
+        padding: 10px 8px;
+        gap: 10px;
+    }
+
+    .showtime-strip,
+    .transcript-panel,
+    .error-box {
+        width: 100%;
+    }
+
     .toolbar {
         flex-wrap: wrap;
         justify-content: flex-start;
@@ -572,6 +583,25 @@ input[type="url"] {
         flex-wrap: nowrap;
         overflow-x: auto;
         padding-bottom: 2px;
+    }
+
+    .slide-stage {
+        padding: 6px;
+        border-radius: 14px;
+    }
+
+    .slide-card,
+    .placeholder {
+        min-height: 62vh;
+        border-radius: 16px;
+        padding: 4px;
+    }
+
+    .slide-card > svg:first-child:last-child {
+        width: 100%;
+        max-width: none;
+        height: auto;
+        display: block;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Mobile displays showed large outer padding and card padding that caused embedded SVG-only slides to appear too small, so the mobile layout should use more of the viewport for slide content.
- Reduce wasted rounded corners and inner spacing on phones so slide visuals (especially detailed SVGs) can render larger and clearer.

### Description
- Adjust `@media (max-width: 820px)` styles to reduce outer stage padding and gap by changing `.stage` to `padding: 10px 8px` and `gap: 10px`.
- Ensure panels stretch to the available width by setting `.showtime-strip`, `.transcript-panel`, and `.error-box` to `width: 100%` inside the mobile breakpoint.
- Tighten the slide container on phones by reducing `.slide-stage` padding and radius and lowering `.slide-card`/`.placeholder` `min-height`, `padding`, and `border-radius` values.
- Add a targeted rule ` .slide-card > svg:first-child:last-child ` so single-embedded-SVG slides scale to `width: 100%` and `height: auto` to better fill the slide area.

### Testing
- Inspected the CSS diff to confirm only additions/adjustments in the `@media (max-width: 820px)` block of `src/styles.css` and that the changes target mobile layout selectors (passed).
- Repository status and diff checks were used to validate the single-file change was as intended (passed).
- No automated browser-based visual tests were executed in this environment due to lack of a headless browser/tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb785c6a54832ab7d54efb904cac71)