### PR TITLE
Make slide-change wait abortable to improve transition cancel responsiveness

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -812,8 +812,11 @@ async function goToSlide(index, options = {}) {
         await audioController.stop();
         if (options.autoplay) {
             const bellDurationSeconds = playSlideChangeCueWithIndicator();
-            await delay((bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000);
-            if (transitionAbortRequested) {
+            const transitionDelayCompleted = await delayWithAbort(
+                (bellDurationSeconds + SLIDE_CHANGE_BELL_PAUSE_SECONDS) * 1000,
+                () => transitionAbortRequested,
+            );
+            if (!transitionDelayCompleted) {
                 return;
             }
         }
@@ -922,6 +925,23 @@ function delay(durationMs) {
     return new Promise((resolve) => {
         window.setTimeout(resolve, durationMs);
     });
+}
+
+async function delayWithAbort(durationMs, shouldAbort, checkIntervalMs = 40) {
+    const safeDurationMs = Math.max(0, Number(durationMs) || 0);
+    if (safeDurationMs === 0) {
+        return !shouldAbort();
+    }
+    const startTime = performance.now();
+    while (performance.now() - startTime < safeDurationMs) {
+        if (shouldAbort()) {
+            return false;
+        }
+        const elapsedMs = performance.now() - startTime;
+        const remainingMs = Math.max(0, safeDurationMs - elapsedMs);
+        await delay(Math.min(checkIntervalMs, remainingMs));
+    }
+    return !shouldAbort();
 }
 
 async function renderCurrentSlide() {


### PR DESCRIPTION
### Motivation
- Abbrechen eines Folienwechsels wurde erst nach Ablauf der gesamten Glocke+Pause wirksam, sodass ein gewünschter sofortiger Stopp verzögert ausgeführt wurde.

### Description
- Ersetze den starren `await delay(...)`-Warteblock in `goToSlide` durch einen abort-sensitiven Aufruf, der sofort aussteigen kann, wenn `transitionAbortRequested` wahr wird.
- Ergänze die Hilfsfunktion `delayWithAbort(durationMs, shouldAbort, checkIntervalMs = 40)`, die in kurzen Intervallen auf `shouldAbort()` prüft und frühzeitig zurückkehrt, wenn ein Abbruch angefordert ist.
- Passe die Logik in `goToSlide` so an, dass bei abgebrochener Wartezeit die Funktion vorzeitig beendet wird und die Transition nicht weiter ausgeführt wird.

### Testing
- Laufzeit-Syntaxprüfung mit `node --check src/app.js` wurde ausgeführt und erfolgreich bestanden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7dbe17b0832aaca05ce0dd44e602)