### PR TITLE
Fix horizontal centering for initial slide

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -425,8 +425,17 @@ function scrollToSlideStageTop() {
 }
 
 function centerSlideStageHorizontally() {
-    const horizontalOverflow = elements.slideStage.scrollWidth - elements.slideStage.clientWidth;
-    elements.slideStage.scrollLeft = Math.max(0, horizontalOverflow / 2);
+    const stage = elements.slideStage;
+    const slideCard = stage.querySelector('.slide-card, .placeholder');
+
+    if (!slideCard) {
+        stage.scrollLeft = 0;
+        return;
+    }
+
+    const targetScrollLeft = slideCard.offsetLeft - ((stage.clientWidth - slideCard.clientWidth) / 2);
+    const maxScrollLeft = Math.max(0, stage.scrollWidth - stage.clientWidth);
+    stage.scrollLeft = Math.min(Math.max(0, targetScrollLeft), maxScrollLeft);
 }
 
 function clearSlideAdvanceTimer() {
@@ -1003,6 +1012,7 @@ async function hydrateAsyncAssets() {
         }
         image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
     }
+    centerSlideStageHorizontally();
 }
 
 async function playCurrentSlide(options = {}) {


### PR DESCRIPTION
### Motivation
- The slide stage centering used the container `scrollWidth` which could produce an incorrect left offset when children (images or other content) were wider, causing the first slide to appear shifted far left.

### Description
- Update `centerSlideStageHorizontally` in `src/app.js` to center based on the actual `.slide-card` / `.placeholder` element by using `slideCard.offsetLeft` and clamping the computed `scrollLeft` to valid bounds.
- Re-run centering after asynchronous asset hydration by calling `centerSlideStageHorizontally` at the end of `hydrateAsyncAssets` so late image loads do not leave an incorrect offset.
- Changes are confined to `src/app.js` (adjusted centering math and added re-centering call).

### Testing
- Ran a syntax check with `node --check src/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7f609b1c832a89cb0f8f3cf3ff30)