### PR TITLE
Add centered non-blocking spinner during slide transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
             <pre id="transcript-text" class="hidden"></pre>
           </section>
         </article>
+        <div id="slide-transition-spinner" class="slide-transition-spinner" aria-hidden="true">
+          <span class="slide-transition-spinner__ring"></span>
+        </div>
 
         <header id="player-toolbar" class="toolbar panel">
           <div class="toolbar-group toolbar-group--primary">

--- a/src/app.js
+++ b/src/app.js
@@ -464,6 +464,7 @@ function setPlayButtonActive(active) {
 function beginSlideTransitionLock() {
     transitionAbortRequested = false;
     isSlideTransitionInProgress = true;
+    setTransitionSpinnerVisible(true);
     refreshUi();
     setSlideListNavigationDisabled(true);
     clearTransitionUnlockTimer();
@@ -478,6 +479,7 @@ function beginSlideTransitionLock() {
 
 function endSlideTransitionLock() {
     isSlideTransitionInProgress = false;
+    setTransitionSpinnerVisible(false);
     clearTransitionUnlockTimer();
     refreshUi();
     setSlideListNavigationDisabled(false);
@@ -488,6 +490,10 @@ function clearTransitionUnlockTimer() {
         window.clearTimeout(transitionUnlockTimer);
         transitionUnlockTimer = null;
     }
+}
+
+function setTransitionSpinnerVisible(visible) {
+    elements.slideTransitionSpinner?.classList.toggle('is-active', Boolean(visible));
 }
 
 function setSlideListNavigationDisabled(disabled) {

--- a/src/layout.js
+++ b/src/layout.js
@@ -11,6 +11,7 @@ const ELEMENT_SELECTORS = {
     slideList: '#slide-list',
     slideStage: '#slide-stage',
     slideContent: '#slide-content',
+    slideTransitionSpinner: '#slide-transition-spinner',
     showtimeStrip: '.showtime-strip',
     showtimeProgressTrack: '#showtime-progress-track',
     showtimeProgress: '#showtime-progress',

--- a/src/styles.css
+++ b/src/styles.css
@@ -384,6 +384,45 @@ input[type="url"] {
     width: 100%;
 }
 
+.slide-transition-spinner {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 74px;
+    height: 74px;
+    transform: translate(-50%, -50%);
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(19, 22, 26, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 999;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 120ms ease-out, visibility 120ms ease-out;
+    pointer-events: none;
+}
+
+.slide-transition-spinner.is-active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.slide-transition-spinner__ring {
+    width: 46px;
+    height: 46px;
+    border-radius: 999px;
+    border: 4px solid rgba(108, 192, 255, 0.35);
+    border-top-color: rgba(108, 192, 255, 0.95);
+    animation: slide-transition-spin 700ms linear infinite;
+}
+
+@keyframes slide-transition-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 .slide-card,
 .placeholder {
     width: min(1200px, 100%);


### PR DESCRIPTION
### Motivation
- Während Folienwechseln soll ein zentrierter Hinweis erscheinen, der anzeigt, dass eine Transition aktiv ist, ohne Touch-/Klick-Interaktion zu blockieren (Issue #123).

### Description
- Fügt ein neues Spinner-Element in die Haupt-Layout-Datei (`index.html`) hinzu, das eine Ring-Animation enthält.
- Nimmt das Element in die zentrale Layout-Sammlung (`src/layout.js`) auf, damit es über `elements` referenziert wird.
- Steuert die Sichtbarkeit des Spinners über `setTransitionSpinnerVisible` in `src/app.js` und blendet ihn beim Start/Ende des Transition-Locks ein/aus.
- Stellt das Erscheinungsbild in `src/styles.css` bereit, wobei der Spinner viewport-zentriert ist und `pointer-events: none` setzt, damit er nicht die Interaktion verhindert.

### Testing
- Repository-Konsistenz- und Statusprüfungen wurden ausgeführt und lieferten keine Fehler.
- Die Änderungen wurden lokal als Änderungssatz erzeugt und die Arbeitskopie zeigte nur die beabsichtigten modifizierten Dateien (`index.html`, `src/layout.js`, `src/app.js`, `src/styles.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba0d731a8832abd055bd129258e2b)