### PR TITLE
Handle pausing/resuming of unavailable-audio fallback advance and reflect it in presentation state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1084,6 +1084,9 @@ function isPresentationRunning() {
     if (nonAudioPlaybackRemainingSeconds !== null) {
         return true;
     }
+    if (audioController.hasRunningFallbackAdvance()) {
+        return true;
+    }
     return elements.audioStatus.textContent.startsWith('Spielt');
 }
 
@@ -1096,6 +1099,7 @@ async function pausePresentation() {
     }
 
     if (!isPresentationRunning()) {
+        await audioController.pause();
         return;
     }
 
@@ -1122,6 +1126,7 @@ async function pausePresentation() {
 
     if (pausedNonAudioRemainingSeconds !== null) {
         elements.audioStatus.textContent = 'Pausiert';
+        await audioController.pause();
         return;
     }
 
@@ -1144,7 +1149,8 @@ async function resumePresentation() {
             seconds: remainingSeconds,
             totalSeconds,
         });
-        if (state.autoAdvance) {
+        const hasPausedFallbackAdvance = audioController.hasPausedFallbackAdvance();
+        if (state.autoAdvance && !hasPausedFallbackAdvance) {
             clearSlideAdvanceTimer();
             slideAdvanceTimer = window.setTimeout(async () => {
                 slideAdvanceTimer = null;
@@ -1154,6 +1160,7 @@ async function resumePresentation() {
                 await handleSlidePlaybackCompleted();
             }, remainingSeconds * 1000);
         }
+        await audioController.resume();
         const currentSlide = state.deck?.slides[state.currentIndex];
         updateSlideAudioStatus(currentSlide);
         return;

--- a/src/audio.js
+++ b/src/audio.js
@@ -10,6 +10,9 @@ export class AudioController {
         this.currentSlideKey = null;
         this.playbackSession = 0;
         this.unavailableAudioFallbackTimer = null;
+        this.unavailableAudioFallbackRemainingMs = null;
+        this.unavailableAudioFallbackDeadline = null;
+        this.unavailableAudioFallbackSession = null;
     }
 
     isSpeechSupported() {
@@ -72,6 +75,11 @@ export class AudioController {
     }
 
     async pause() {
+        if (this.pauseFallbackAdvance()) {
+            this.updateStatus('Pausiert');
+            return;
+        }
+
         if (this.audio && !this.audio.paused) {
             this.audio.pause();
             this.updateStatus('Pausiert');
@@ -85,6 +93,11 @@ export class AudioController {
     }
 
     async resume() {
+        if (this.resumeFallbackAdvance()) {
+            this.updateStatus('Spielt');
+            return;
+        }
+
         if (this.audio && this.audio.paused) {
             await this.audio.play();
             this.updateStatus('Spielt');
@@ -114,6 +127,18 @@ export class AudioController {
 
         this.currentSlideKey = null;
         this.updateStatus('Gestoppt');
+    }
+
+    hasRunningFallbackAdvance() {
+        return this.unavailableAudioFallbackTimer !== null;
+    }
+
+    hasPausedFallbackAdvance() {
+        return (
+            this.unavailableAudioFallbackTimer === null &&
+            this.unavailableAudioFallbackRemainingMs !== null &&
+            this.unavailableAudioFallbackSession !== null
+        );
     }
 
     async playAudioElement(url, playbackSession, slide = {}) {
@@ -206,21 +231,70 @@ export class AudioController {
         this.clearUnavailableAudioFallbackTimer();
         const fallbackSeconds = getUnavailableAudioShowtimeSeconds(slide);
         this.onFallbackTimerStart?.(fallbackSeconds);
+        this.unavailableAudioFallbackRemainingMs = fallbackSeconds * 1000;
+        this.unavailableAudioFallbackSession = playbackSession;
+        this.unavailableAudioFallbackDeadline = performance.now() + this.unavailableAudioFallbackRemainingMs;
         this.unavailableAudioFallbackTimer = window.setTimeout(() => {
             this.unavailableAudioFallbackTimer = null;
+            this.unavailableAudioFallbackRemainingMs = null;
+            this.unavailableAudioFallbackDeadline = null;
+            this.unavailableAudioFallbackSession = null;
             if (!this.isCurrentPlaybackSession(playbackSession)) {
                 return;
             }
             this.onEnded?.();
-        }, fallbackSeconds * 1000);
+        }, this.unavailableAudioFallbackRemainingMs);
     }
 
     clearUnavailableAudioFallbackTimer() {
         if (!this.unavailableAudioFallbackTimer) {
+            this.unavailableAudioFallbackRemainingMs = null;
+            this.unavailableAudioFallbackDeadline = null;
+            this.unavailableAudioFallbackSession = null;
             return;
         }
         window.clearTimeout(this.unavailableAudioFallbackTimer);
         this.unavailableAudioFallbackTimer = null;
+        this.unavailableAudioFallbackRemainingMs = null;
+        this.unavailableAudioFallbackDeadline = null;
+        this.unavailableAudioFallbackSession = null;
+    }
+
+    pauseFallbackAdvance() {
+        if (!this.unavailableAudioFallbackTimer || this.unavailableAudioFallbackDeadline === null) {
+            return false;
+        }
+        const remainingMs = Math.max(0, this.unavailableAudioFallbackDeadline - performance.now());
+        window.clearTimeout(this.unavailableAudioFallbackTimer);
+        this.unavailableAudioFallbackTimer = null;
+        this.unavailableAudioFallbackRemainingMs = remainingMs;
+        this.unavailableAudioFallbackDeadline = null;
+        return true;
+    }
+
+    resumeFallbackAdvance() {
+        if (
+            this.unavailableAudioFallbackTimer ||
+            this.unavailableAudioFallbackRemainingMs === null ||
+            this.unavailableAudioFallbackSession === null
+        ) {
+            return false;
+        }
+
+        const remainingMs = this.unavailableAudioFallbackRemainingMs;
+        const playbackSession = this.unavailableAudioFallbackSession;
+        this.unavailableAudioFallbackDeadline = performance.now() + remainingMs;
+        this.unavailableAudioFallbackTimer = window.setTimeout(() => {
+            this.unavailableAudioFallbackTimer = null;
+            this.unavailableAudioFallbackRemainingMs = null;
+            this.unavailableAudioFallbackDeadline = null;
+            this.unavailableAudioFallbackSession = null;
+            if (!this.isCurrentPlaybackSession(playbackSession)) {
+                return;
+            }
+            this.onEnded?.();
+        }, remainingMs);
+        return true;
     }
 
     updateStatus(status) {


### PR DESCRIPTION
### Motivation
- Ensure the fallback slideshow-advance used when audio is unavailable can be paused and resumed when the presentation itself is paused or resumed.
- Make presentation-running state aware of a running fallback advance so touch toggles and pause/resume logic behave correctly.

### Description
- Added tracking fields `unavailableAudioFallbackRemainingMs`, `unavailableAudioFallbackDeadline`, and `unavailableAudioFallbackSession` to `AudioController` and persisted remaining time when a fallback advance is scheduled in `scheduleFallbackAdvance`.
- Implemented `hasRunningFallbackAdvance`, `hasPausedFallbackAdvance`, `pauseFallbackAdvance`, and `resumeFallbackAdvance` on `AudioController`, and updated `clearUnavailableAudioFallbackTimer` to clear the new fields.
- Updated `play/pause/resume/stop` flows in `app.js` to call `audioController.pause()`/`audioController.resume()` where appropriate and to treat a running fallback advance as part of the presentation running state via `isPresentationRunning()`.
- Prevented automatic slide-advance timers from being created during resume when a fallback advance is paused by checking `audioController.hasPausedFallbackAdvance()`.

### Testing
- Ran the automated test suite with `npm test`, and all tests passed.
- Ran `npm run lint` to verify formatting and code quality, and the linter passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebad0bc758832a9dff71a41f65905b)