### PR TITLE
Nicht-blockierender Spinner für asynchrone Folien-Assets

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -72,6 +72,11 @@ let showtimeCountdownTotalSeconds = null;
 let currentErrorMessage = '';
 let isErrorExpanded = false;
 let isPausedByErrorToggle = false;
+let asyncAssetHydrationToken = 0;
+const spinnerState = {
+    transitionLock: false,
+    asyncAssetLoading: false,
+};
 
 await initApp();
 
@@ -467,7 +472,7 @@ function setPlayButtonActive(active) {
 function beginSlideTransitionLock() {
     transitionAbortRequested = false;
     isSlideTransitionInProgress = true;
-    setTransitionSpinnerVisible(true);
+    setTransitionSpinnerState('transitionLock', true);
     refreshUi();
     setSlideListNavigationDisabled(true);
     clearTransitionUnlockTimer();
@@ -482,7 +487,7 @@ function beginSlideTransitionLock() {
 
 function endSlideTransitionLock() {
     isSlideTransitionInProgress = false;
-    setTransitionSpinnerVisible(false);
+    setTransitionSpinnerState('transitionLock', false);
     clearTransitionUnlockTimer();
     refreshUi();
     setSlideListNavigationDisabled(false);
@@ -495,8 +500,13 @@ function clearTransitionUnlockTimer() {
     }
 }
 
-function setTransitionSpinnerVisible(visible) {
-    elements.slideTransitionSpinner?.classList.toggle('is-active', Boolean(visible));
+function setTransitionSpinnerState(reason, visible) {
+    if (!(reason in spinnerState)) {
+        return;
+    }
+    spinnerState[reason] = Boolean(visible);
+    const shouldShow = Object.values(spinnerState).some(Boolean);
+    elements.slideTransitionSpinner?.classList.toggle('is-active', shouldShow);
 }
 
 function setSlideListNavigationDisabled(disabled) {
@@ -972,6 +982,7 @@ async function renderCurrentSlide() {
     clearSlideAdvanceTimer();
     clearShowtimeCountdown();
     nonAudioPlaybackRemainingSeconds = null;
+    abortPendingAssetHydration();
     setPlayButtonActive(false);
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
@@ -1000,7 +1011,7 @@ async function renderCurrentSlide() {
   `;
     centerSlideStageHorizontally();
 
-    await hydrateAsyncAssets();
+    void hydrateAsyncAssets();
 
     if (!slide.audio) {
         updateSlideAudioStatus(slide);
@@ -1018,15 +1029,37 @@ async function renderCurrentSlide() {
     }
 }
 
+function abortPendingAssetHydration() {
+    asyncAssetHydrationToken += 1;
+    setTransitionSpinnerState('asyncAssetLoading', false);
+}
+
 async function hydrateAsyncAssets() {
+    const hydrationToken = ++asyncAssetHydrationToken;
     const images = [...elements.slideStage.querySelectorAll('img[src=""]')];
+    if (images.length === 0) {
+        setTransitionSpinnerState('asyncAssetLoading', false);
+        return;
+    }
+    setTransitionSpinnerState('asyncAssetLoading', true);
     for (const image of images) {
+        if (hydrationToken !== asyncAssetHydrationToken) {
+            return;
+        }
         const original = image.getAttribute('data-original-src');
         if (!original) {
             continue;
         }
-        image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
+        try {
+            image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
+        } catch (error) {
+            console.warn('Bild konnte nicht geladen werden.', error);
+        }
     }
+    if (hydrationToken !== asyncAssetHydrationToken) {
+        return;
+    }
+    setTransitionSpinnerState('asyncAssetLoading', false);
     centerSlideStageHorizontally();
 }
 


### PR DESCRIPTION
### Motivation
- Der Ladeindikator sollte nicht an den Navigations-Lock gekoppelt sein, damit der Nutzer weiterhin Feedback beim Nachladen von Assets bekommt. 
- Folienwechsel dürfen nicht durch langsame Bild-Nachladungen blockiert werden. 
- Stale asynchrone Ladevorgänge müssen abgebrochen werden, damit ältere Bild-Loads nicht neu geladene Folien überschreiben und die UI inkonsistent wird.

### Description
- Introduced a reason-based spinner state with `spinnerState` and the new function `setTransitionSpinnerState(reason, visible)` to decouple spinner visibility from transition locking. 
- Added `asyncAssetHydrationToken` plus `abortPendingAssetHydration()` and token checks in `hydrateAsyncAssets()` to cancel stale async asset loads. 
- Changed `renderCurrentSlide()` to call `abortPendingAssetHydration()` and start image hydration non-blocking via `void hydrateAsyncAssets()` instead of awaiting it. 
- Wrapped image URL resolution in a `try/catch` to log individual image load failures and ensure the spinner is hidden when hydration completes or is cancelled.

### Testing
- Ran a static syntax check with `node --check src/app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb1d69e7c832ab0717151cdd7a5ae)