### PR TITLE
Consolidate transition spinner; show loading label; async asset hydration with abort and protected deck loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         </article>
         <div id="slide-transition-spinner" class="slide-transition-spinner" aria-hidden="true">
           <span class="slide-transition-spinner__ring"></span>
+          <span class="slide-transition-spinner__label">Lädt…</span>
         </div>
 
         <header id="player-toolbar" class="toolbar panel">

--- a/src/app.js
+++ b/src/app.js
@@ -72,6 +72,13 @@ let showtimeCountdownTotalSeconds = null;
 let currentErrorMessage = '';
 let isErrorExpanded = false;
 let isPausedByErrorToggle = false;
+let asyncAssetHydrationToken = 0;
+const spinnerState = {
+    transitionLock: false,
+    asyncAssetLoading: false,
+    deckLoading: false,
+    slideRendering: false,
+};
 
 await initApp();
 
@@ -146,7 +153,7 @@ function cleanupApplication() {
 function bindEvents() {
     elements.pickDirectoryBtn.addEventListener('click', async () => {
         await withUiErrorHandling(async () => {
-            const deck = await loadDeckFromDirectory();
+            const deck = await withSpinner('deckLoading', async () => loadDeckFromDirectory(), {allowPaint: true});
             await setDeck(deck);
         });
     });
@@ -157,7 +164,7 @@ function bindEvents() {
             return;
         }
         await withUiErrorHandling(async () => {
-            const deck = await loadDeckFromZip(file);
+            const deck = await withSpinner('deckLoading', async () => loadDeckFromZip(file), {allowPaint: true});
             await setDeck(deck);
             event.target.value = '';
         });
@@ -169,7 +176,7 @@ function bindEvents() {
             if (!url) {
                 throw new Error('Bitte eine Remote-URL eingeben.');
             }
-            const deck = await loadDeckFromRemote(url);
+            const deck = await withSpinner('deckLoading', async () => loadDeckFromRemote(url), {allowPaint: true});
             await setDeck(deck);
         });
     });
@@ -467,7 +474,7 @@ function setPlayButtonActive(active) {
 function beginSlideTransitionLock() {
     transitionAbortRequested = false;
     isSlideTransitionInProgress = true;
-    setTransitionSpinnerVisible(true);
+    setTransitionSpinnerState('transitionLock', true);
     refreshUi();
     setSlideListNavigationDisabled(true);
     clearTransitionUnlockTimer();
@@ -482,7 +489,7 @@ function beginSlideTransitionLock() {
 
 function endSlideTransitionLock() {
     isSlideTransitionInProgress = false;
-    setTransitionSpinnerVisible(false);
+    setTransitionSpinnerState('transitionLock', false);
     clearTransitionUnlockTimer();
     refreshUi();
     setSlideListNavigationDisabled(false);
@@ -495,8 +502,31 @@ function clearTransitionUnlockTimer() {
     }
 }
 
-function setTransitionSpinnerVisible(visible) {
-    elements.slideTransitionSpinner?.classList.toggle('is-active', Boolean(visible));
+function setTransitionSpinnerState(reason, visible) {
+    if (!(reason in spinnerState)) {
+        return;
+    }
+    spinnerState[reason] = Boolean(visible);
+    const shouldShow = Object.values(spinnerState).some(Boolean);
+    elements.slideTransitionSpinner?.classList.toggle('is-active', shouldShow);
+}
+
+function nextAnimationFrame() {
+    return new Promise((resolve) => {
+        window.requestAnimationFrame(() => resolve());
+    });
+}
+
+async function withSpinner(reason, task, {allowPaint = false} = {}) {
+    setTransitionSpinnerState(reason, true);
+    if (allowPaint) {
+        await nextAnimationFrame();
+    }
+    try {
+        return await task();
+    } finally {
+        setTransitionSpinnerState(reason, false);
+    }
 }
 
 function setSlideListNavigationDisabled(disabled) {
@@ -794,7 +824,7 @@ async function initializeFromQueryParameters() {
     elements.remoteUrlInput.value = remoteUrl;
 
     await withUiErrorHandling(async () => {
-        const deck = await loadDeckFromRemote(remoteUrl);
+        const deck = await withSpinner('deckLoading', async () => loadDeckFromRemote(remoteUrl), {allowPaint: true});
         await setDeck(deck);
     });
 }
@@ -972,6 +1002,7 @@ async function renderCurrentSlide() {
     clearSlideAdvanceTimer();
     clearShowtimeCountdown();
     nonAudioPlaybackRemainingSeconds = null;
+    abortPendingAssetHydration();
     setPlayButtonActive(false);
     const slide = state.deck?.slides[state.currentIndex];
     if (!slide) {
@@ -992,15 +1023,17 @@ async function renderCurrentSlide() {
         return resolved;
     };
 
-    const html = renderSlideContent(slide, assetResolver);
-    elements.slideContent.innerHTML = `
+    await withSpinner('slideRendering', async () => {
+        const html = renderSlideContent(slide, assetResolver);
+        elements.slideContent.innerHTML = `
     <article class="slide-card" data-slide-id="${escapeHtml(slide.id || '')}">
       ${html}
     </article>
   `;
-    centerSlideStageHorizontally();
+        centerSlideStageHorizontally();
+    }, {allowPaint: true});
 
-    await hydrateAsyncAssets();
+    void hydrateAsyncAssets();
 
     if (!slide.audio) {
         updateSlideAudioStatus(slide);
@@ -1018,15 +1051,37 @@ async function renderCurrentSlide() {
     }
 }
 
+function abortPendingAssetHydration() {
+    asyncAssetHydrationToken += 1;
+    setTransitionSpinnerState('asyncAssetLoading', false);
+}
+
 async function hydrateAsyncAssets() {
+    const hydrationToken = ++asyncAssetHydrationToken;
     const images = [...elements.slideStage.querySelectorAll('img[src=""]')];
+    if (images.length === 0) {
+        setTransitionSpinnerState('asyncAssetLoading', false);
+        return;
+    }
+    setTransitionSpinnerState('asyncAssetLoading', true);
     for (const image of images) {
+        if (hydrationToken !== asyncAssetHydrationToken) {
+            return;
+        }
         const original = image.getAttribute('data-original-src');
         if (!original) {
             continue;
         }
-        image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
+        try {
+            image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
+        } catch (error) {
+            console.warn('Bild konnte nicht geladen werden.', error);
+        }
     }
+    if (hydrationToken !== asyncAssetHydrationToken) {
+        return;
+    }
+    setTransitionSpinnerState('asyncAssetLoading', false);
     centerSlideStageHorizontally();
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -388,14 +388,16 @@ input[type="url"] {
     position: fixed;
     top: 50%;
     left: 50%;
-    width: 74px;
-    height: 74px;
+    width: 96px;
+    height: 96px;
     transform: translate(-50%, -50%);
     display: grid;
     place-items: center;
+    gap: 6px;
     border-radius: 999px;
-    background: rgba(19, 22, 26, 0.55);
-    backdrop-filter: blur(2px);
+    background: rgba(19, 22, 26, 0.72);
+    backdrop-filter: blur(3px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
     z-index: 999;
     opacity: 0;
     visibility: hidden;
@@ -409,12 +411,18 @@ input[type="url"] {
 }
 
 .slide-transition-spinner__ring {
-    width: 46px;
-    height: 46px;
+    width: 44px;
+    height: 44px;
     border-radius: 999px;
     border: 4px solid rgba(108, 192, 255, 0.35);
     border-top-color: rgba(108, 192, 255, 0.95);
     animation: slide-transition-spin 700ms linear infinite;
+}
+
+.slide-transition-spinner__label {
+    font-size: 12px;
+    color: #dbeafe;
+    letter-spacing: 0.02em;
 }
 
 @keyframes slide-transition-spin {


### PR DESCRIPTION
### Motivation
- Provide a single, reason-aware transition spinner so overlapping async operations (deck load, slide render, asset hydration, transition lock) can share one UI indicator. 
- Surface a small localized loading label and improve spinner visuals for clearer feedback during long operations. 
- Prevent races while hydrating async slide assets and make async image loading resilient to failures and cancellation.

### Description
- Introduce a `spinnerState` map and replace the old boolean spinner control with `setTransitionSpinnerState(reason, visible)` so multiple reasons can control the single spinner element. 
- Add `withSpinner(reason, task, {allowPaint})` and `nextAnimationFrame()` helpers and use them to wrap deck loading operations (`loadDeckFromDirectory`, `loadDeckFromZip`, `loadDeckFromRemote`, query-param init) and slide rendering with optional paint allowance. 
- Add async asset hydration cancellation via `asyncAssetHydrationToken` and `abortPendingAssetHydration()`, convert `hydrateAsyncAssets()` to set spinner state for `asyncAssetLoading`, handle cancellation, and catch image loading errors. 
- Adjust slide transition lock to set spinner state for `transitionLock` and update callers to use the new API. 
- Add UI label markup (`Lädt…`) to the spinner in `index.html` and update spinner styling in `src/styles.css` (size, background, blur, shadow, spacing, and label styles). 

### Testing
- Ran the existing automated test suite via `npm test` and linting; the suite completed successfully. 
- Performed automated build with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb1d69e7c832ab0717151cdd7a5ae)