### PR TITLE
Asynchrone Hydration für Markdown-Bilder reparieren

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1016,11 +1016,7 @@ async function renderCurrentSlide() {
     }
 
     const assetResolver = (assetPath) => {
-        const resolved = state.deck.assetLoader.resolveAssetPath(assetPath);
-        if (resolved instanceof Promise) {
-            return '';
-        }
-        return resolved;
+        return state.deck.assetLoader.resolveAssetPath(assetPath);
     };
 
     await withSpinner('slideRendering', async () => {
@@ -1058,7 +1054,7 @@ function abortPendingAssetHydration() {
 
 async function hydrateAsyncAssets() {
     const hydrationToken = ++asyncAssetHydrationToken;
-    const images = [...elements.slideStage.querySelectorAll('img[src=""]')];
+    const images = [...elements.slideStage.querySelectorAll('img[data-sld-asset]')];
     if (images.length === 0) {
         setTransitionSpinnerState('asyncAssetLoading', false);
         return;
@@ -1068,12 +1064,13 @@ async function hydrateAsyncAssets() {
         if (hydrationToken !== asyncAssetHydrationToken) {
             return;
         }
-        const original = image.getAttribute('data-original-src');
-        if (!original) {
+        const assetPath = image.getAttribute('data-sld-asset');
+        if (!assetPath) {
             continue;
         }
         try {
-            image.src = await state.deck.assetLoader.resolvePlayableUrl(original);
+            image.src = await state.deck.assetLoader.resolveAssetPath(assetPath);
+            image.removeAttribute('data-sld-asset');
         } catch (error) {
             console.warn('Bild konnte nicht geladen werden.', error);
         }

--- a/src/wiki-parser.js
+++ b/src/wiki-parser.js
@@ -11,15 +11,17 @@ export function renderSlideContent(slide, assetResolver) {
 
   const renderer = new marked.Renderer();
   renderer.image = ({ href, title, text }) => {
-    const resolved = assetResolver(href);
+    const safeHref = typeof href === 'string' ? href : '';
+    const resolved = assetResolver(safeHref);
     const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
     const alt = escapeHtml(text || '');
+    const assetPathAttr = ` data-sld-asset="${escapeHtml(safeHref)}"`;
 
     if (resolved instanceof Promise) {
-      return `<img src="" data-original-src="${escapeHtml(href)}" alt="${alt}"${titleAttr}>`;
+      return `<img src="" alt="${alt}"${titleAttr}${assetPathAttr}>`;
     }
 
-    return `<img src="${resolved}" alt="${alt}"${titleAttr}>`;
+    return `<img src="${escapeHtml(resolved)}" alt="${alt}"${titleAttr}${assetPathAttr}>`;
   };
 
   const rendered = marked.parse(raw, { renderer });


### PR DESCRIPTION
### Motivation
- Markdown-Bilder aus gebündelten SLD/ZIP-Quellen wurden nicht zuverlässig asynchron aufgelöst (z.B. SVGs aus ZIP), da der Renderer auf `src=""`/`data-original-src` gesetzt hat und die Hydration darauf abzielte.
- Die Implementierung muss konsistent mit `resolveAssetPath(...)` für alle Asset-Typen arbeiten und robust gegenüber nicht-string `href`-Werten sein.

### Description
- Markdown-Renderer in `src/wiki-parser.js` setzt stets ein `data-sld-asset`-Attribut und verwendet einen sicheren `safeHref`-Fallback für nicht-string `href`-Werte.
- Direkte, bereits aufgelöste URLs werden jetzt mit `escapeHtml(...)` ausgegeben und ebenfalls mit `data-sld-asset` markiert, damit die Hydration einheitlich funktioniert.
- In `src/app.js` gibt `assetResolver` nun direkt `state.deck.assetLoader.resolveAssetPath(...)` zurück, so dass asynchrone Auflösung nicht vorzeitig unterdrückt wird.
- Die Hydration-Logik wurde auf `img[data-sld-asset]` umgestellt und lädt die Assets mittels `resolveAssetPath(...)`, entfernt nach erfolgreichem Laden das Marker-Attribut und ersetzt damit die alte `data-original-src`/`img[src=""]`-Kopplung.

### Testing
- Type-Check mit `node --check src/wiki-parser.js` wurde ausgeführt und war erfolgreich.
- Type-Check mit `node --check src/app.js` wurde ausgeführt und war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece080b264832ab59b06239f71a098)