### PR TITLE
Fix duplicate markdown image hydration for sync assets (#134)

### DIFF
--- a/src/wiki-parser.js
+++ b/src/wiki-parser.js
@@ -15,13 +15,13 @@ export function renderSlideContent(slide, assetResolver) {
     const resolved = assetResolver(safeHref);
     const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
     const alt = escapeHtml(text || '');
-    const assetPathAttr = ` data-sld-asset="${escapeHtml(safeHref)}"`;
 
     if (resolved instanceof Promise) {
+      const assetPathAttr = ` data-sld-asset="${escapeHtml(safeHref)}"`;
       return `<img src="" alt="${alt}"${titleAttr}${assetPathAttr}>`;
     }
 
-    return `<img src="${escapeHtml(resolved)}" alt="${alt}"${titleAttr}${assetPathAttr}>`;
+    return `<img src="${escapeHtml(resolved)}" alt="${alt}"${titleAttr}>`;
   };
 
   const rendered = marked.parse(raw, { renderer });


### PR DESCRIPTION
### Motivation
- Prevent markdown images whose URLs are resolved synchronously from being marked for async hydration and reloaded unnecessarily, which caused duplicate hydration passes and redundant image load attempts.

### Description
- Adjusted `renderer.image` in `src/wiki-parser.js` so `data-sld-asset` is only added when `assetResolver` returns a `Promise`, and synchronous resolutions are written directly to `src`.
- This removes the hydration metadata for already-resolved images and keeps async-hydration logic (in `hydrateAsyncAssets`) targeted at genuinely async assets.

### Testing
- Ran `node --check src/wiki-parser.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf1176074832a9add82c018ba7d8f)